### PR TITLE
docs: sync npm 1.1.0 release status

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 <p align="center">
   <a href="https://www.dsheval.ai"><img alt="在线体验" src="https://img.shields.io/badge/在线体验-Visit-5865f2?style=flat-square"></a>
   <a href="./CHANGELOG.md"><img alt="正式版本 v1.1.0" src="https://img.shields.io/badge/release-v1.1.0-2f6f68?style=flat-square"></a>
+  <a href="https://www.npmjs.com/package/@dsheval/dsh-top100-plugin"><img alt="npm latest" src="https://img.shields.io/npm/v/%40dsheval%2Fdsh-top100-plugin?style=flat-square&label=npm&color=cb3837"></a>
   <a href="https://www.dsheval.ai/?page=dsh#dsh"><img alt="安装 dsh-Top100" src="https://img.shields.io/badge/安装指南-接入_DSH-f2b84b?style=flat-square"></a>
   <a href="./CONTRIBUTING.md"><img alt="参与贡献" src="https://img.shields.io/badge/Contribute-参与贡献-555?style=flat-square&logo=github"></a>
   <a href="https://github.com/dsheval/dsh-top100/issues/new?labels=submission&title=%5BSubmit%5D%20owner%2Frepo"><img alt="提交插件" src="https://img.shields.io/badge/提交插件-Submit-2ea44f?style=flat-square"></a>
@@ -32,6 +33,8 @@
 ## DSH 插件
 
 dsh-Top100 提供可独立安装的 DSH 插件，让用户直接在 DSH 设置页浏览 Top 100、新锐榜、总榜和分类榜，搜索插件，并对作者明确提供且验证通过的安装源进行单项确认安装。安装包自带 `recommend-dsh-plugins` Skill：当用户在 DSH 对话中询问该装哪个插件、请求插件推荐或描述想增加的能力时，模型会加载该 Skill，通过 `dsh_top100_search` 查询实时市场并给出有数据依据的推荐。
+
+当前稳定版本为 [`@dsheval/dsh-top100-plugin@1.1.0`](https://www.npmjs.com/package/@dsheval/dsh-top100-plugin/v/1.1.0)，已发布到 npm 并标记为 `latest`。
 
 点击下面的安装指南会打开 DSHeval 官网，并显示普通用户所需的安装、启动命令；源码运行方式和问题排查收在页面下方。这个入口不会自动下载文件，也不会自动修改电脑。
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -31,7 +31,7 @@ docker compose ps
 
 ## 3. 当前 Git 状态
 
-正式稳定基线为 `main` 分支的最新正式标签，当前发布目标为 `v1.1.0`，远端为：
+正式稳定基线为 `main` 分支的最新正式标签，当前正式版本为 `v1.1.0`，远端为：
 
 ```text
 origin  https://github.com/dsheval/dsh-top100.git

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -4,7 +4,7 @@
 
 **[一键下载并查看接入 DSH 指南](https://www.dsheval.ai/?page=dsh#dsh)**
 
-当前源码版本：**v1.1.0**。
+当前发布版本：[`@dsheval/dsh-top100-plugin@1.1.0`](https://www.npmjs.com/package/@dsheval/dsh-top100-plugin/v/1.1.0)，npm dist-tag 为 `latest`。
 
 需要 **dsh web 0.1.0-rc.6+**。本机开发按官方手册的 bundle 安装方式挂载。
 

--- a/web/public/dsh.html
+++ b/web/public/dsh.html
@@ -103,7 +103,7 @@
       </details>
 
       <p class="dsh-release-note">
-        <strong>当前源码版本：</strong><a href="https://github.com/dsheval/dsh-top100/releases/tag/v1.1.0" target="_blank" rel="noreferrer"><code>@dsheval/dsh-top100-plugin@1.1.0</code></a>，适配 DSH Web 0.1.0-rc.6+。
+        <strong>当前发布版本：</strong><a href="https://www.npmjs.com/package/@dsheval/dsh-top100-plugin/v/1.1.0" target="_blank" rel="noreferrer"><code>@dsheval/dsh-top100-plugin@1.1.0</code></a>，已发布到 npm（<code>latest</code>），适配 DSH Web 0.1.0-rc.6+。
       </p>
     </section>
 


### PR DESCRIPTION
## 改动

- README 增加 npm `latest` 徽章和 `1.1.0` 包链接。
- 插件 README 与官网安装页统一显示“当前发布版本”，并链接 npm。
- 交接文档将 `v1.1.0` 从“发布目标”更新为“正式版本”。

GitHub Release `v1.1.0` 和已合并 PR #2 中“npm 尚未发布”的说明也已同步更新。

## 验证

- `npm run check` 通过
- Collector 79 项测试通过
- Plugin 104 项测试通过
- 发布文案断言与 `git diff --check` 通过

## 后续

合并后需要重新部署官网，线上安装页才会从 `1.0.1` 更新为 `1.1.0`。
