### PR TITLE
docs: 恢复 README 居中标题与徽章布局

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,34 @@
-# dsh-top100
+<p align="center">
+  <img src="./docs/assets/dsh-top100-readme-cover.png" alt="dsh-top100 · Verified DeepSeek Harness plugin rankings" width="100%">
+</p>
 
-发现值得安装的 DeepSeek Harness 插件。
+<h1 align="center">dsh-top100</h1>
+
+<p align="center">
+  <strong>发现、验证并追踪真正值得关注的 DeepSeek Harness 插件。</strong><br>
+  <sub>Verified DSH plugins ranked by GitHub signals, with Skills in a separate discovery directory.</sub>
+</p>
+
+<p align="center">
+  <a href="https://www.dsheval.ai"><img alt="在线体验" src="https://img.shields.io/badge/在线体验-Visit-5865f2?style=flat-square"></a>
+  <a href="https://github.com/dsheval/dsh-top100/releases/tag/v1.3.0"><img alt="正式版本 v1.3.0" src="https://img.shields.io/badge/release-v1.3.0-2f6f68?style=flat-square"></a>
+  <a href="https://www.npmjs.com/package/@dsheval/dsh-top100-plugin"><img alt="npm latest" src="https://img.shields.io/npm/v/%40dsheval%2Fdsh-top100-plugin?style=flat-square&label=npm&color=cb3837"></a>
+  <a href="https://www.dsheval.ai/?page=dsh#dsh"><img alt="安装 dsh-top100" src="https://img.shields.io/badge/安装指南-接入_DSH-f2b84b?style=flat-square"></a>
+  <a href="./CONTRIBUTING.md"><img alt="参与贡献" src="https://img.shields.io/badge/Contribute-参与贡献-555?style=flat-square&logo=github"></a>
+  <a href="https://github.com/dsheval/dsh-top100/issues/new?labels=submission&title=%5BSubmit%5D%20owner%2Frepo"><img alt="提交插件" src="https://img.shields.io/badge/提交插件-Submit-2ea44f?style=flat-square"></a>
+  <a href="https://github.com/dsheval/dsh-top100/stargazers"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/dsheval/dsh-top100?style=flat-square&logo=github&label=Stars"></a>
+  <a href="https://www.dsheval.ai/#ranking"><img alt="收录规模以实时榜单为准" src="https://img.shields.io/badge/收录-实时更新-5865f2?style=flat-square"></a>
+  <a href="./LICENSE"><img alt="MIT License" src="https://img.shields.io/github/license/dsheval/dsh-top100?style=flat-square&label=License"></a>
+  <a href="https://github.com/dsheval/dsh-top100/actions/workflows/ci.yml"><img alt="CI Status" src="https://img.shields.io/github/actions/workflow/status/dsheval/dsh-top100/ci.yml?branch=main&style=flat-square&label=CI"></a>
+  <a href="https://www.dsheval.ai"><img alt="每日 06:00 自动更新" src="https://img.shields.io/badge/每日自动更新-06%3A00-2ea44f?style=flat-square"></a>
+</p>
+
+<p align="center">
+  <strong>官方网站：</strong>
+  <a href="https://www.dsheval.ai"><strong>https://www.dsheval.ai</strong></a>
+</p>
 
 在官网浏览榜单，也可以把榜单带进 DSH，发现、安装和管理插件。综合热度、新锐榜和 Stars 总榜提供不同的比较视角；Skills 保持独立目录。
-
-[访问官网](https://www.dsheval.ai/) · [安装指南](https://www.dsheval.ai/?page=dsh#dsh) · [npm 插件](https://www.npmjs.com/package/@dsheval/dsh-top100-plugin) · [提交插件](https://github.com/dsheval/dsh-top100/issues/new?labels=submission&title=%5BSubmit%5D%20owner%2Frepo) · [参与贡献](./CONTRIBUTING.md)
-
-[![npm](https://img.shields.io/npm/v/%40dsheval%2Fdsh-top100-plugin?label=npm&color=2f6f68)](https://www.npmjs.com/package/@dsheval/dsh-top100-plugin)
-[![CI](https://img.shields.io/github/actions/workflow/status/dsheval/dsh-top100/ci.yml?branch=main&label=CI)](https://github.com/dsheval/dsh-top100/actions/workflows/ci.yml)
-[![MIT License](https://img.shields.io/badge/license-MIT-555)](./LICENSE)
 
 ## 可以做什么
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,10 +1,38 @@
-# dsh-top100 · DSH 插件
+<p align="center">
+  <img src="https://raw.githubusercontent.com/dsheval/dsh-top100/main/docs/assets/dsh-top100-readme-cover.png" alt="dsh-top100 · Verified DeepSeek Harness plugin rankings" width="100%">
+</p>
 
-把插件榜单带进 DSH，发现、安装和管理插件。
+<h1 align="center">dsh-top100 · DSH 插件</h1>
+
+<p align="center">
+  <strong>把插件榜单带进 DSH，发现、安装和管理插件。</strong><br>
+  <sub>Discover and manage DeepSeek Harness plugins in DSH Web, with Skills in a separate directory.</sub>
+</p>
+
+<p align="center">
+  <a href="https://www.dsheval.ai"><img alt="在线体验" src="https://img.shields.io/badge/在线体验-Visit-5865f2?style=flat-square"></a>
+  <a href="https://github.com/dsheval/dsh-top100/releases/tag/v1.3.0"><img alt="正式版本 v1.3.0" src="https://img.shields.io/badge/release-v1.3.0-2f6f68?style=flat-square"></a>
+  <a href="https://www.npmjs.com/package/@dsheval/dsh-top100-plugin"><img alt="npm latest" src="https://img.shields.io/npm/v/%40dsheval%2Fdsh-top100-plugin?style=flat-square&label=npm&color=cb3837"></a>
+  <a href="https://www.dsheval.ai/?page=dsh#dsh"><img alt="安装 dsh-top100" src="https://img.shields.io/badge/安装指南-接入_DSH-f2b84b?style=flat-square"></a>
+  <a href="https://github.com/dsheval/dsh-top100/blob/main/CONTRIBUTING.md"><img alt="参与贡献" src="https://img.shields.io/badge/Contribute-参与贡献-555?style=flat-square&logo=github"></a>
+  <a href="https://github.com/dsheval/dsh-top100/issues/new?labels=submission&title=%5BSubmit%5D%20owner%2Frepo"><img alt="提交插件" src="https://img.shields.io/badge/提交插件-Submit-2ea44f?style=flat-square"></a>
+  <a href="https://github.com/dsheval/dsh-top100/stargazers"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/dsheval/dsh-top100?style=flat-square&logo=github&label=Stars"></a>
+  <a href="https://www.dsheval.ai/#ranking"><img alt="收录规模以实时榜单为准" src="https://img.shields.io/badge/收录-实时更新-5865f2?style=flat-square"></a>
+  <a href="https://github.com/dsheval/dsh-top100/blob/main/LICENSE"><img alt="MIT License" src="https://img.shields.io/github/license/dsheval/dsh-top100?style=flat-square&label=License"></a>
+  <a href="https://github.com/dsheval/dsh-top100/actions/workflows/ci.yml"><img alt="CI Status" src="https://img.shields.io/github/actions/workflow/status/dsheval/dsh-top100/ci.yml?branch=main&style=flat-square&label=CI"></a>
+  <a href="https://www.dsheval.ai"><img alt="每日 06:00 自动更新" src="https://img.shields.io/badge/每日自动更新-06%3A00-2ea44f?style=flat-square"></a>
+</p>
+
+<p align="center">
+  <strong>官方网站：</strong>
+  <a href="https://www.dsheval.ai"><strong>https://www.dsheval.ai</strong></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/dsheval/dsh-top100">GitHub 源码</a> · <a href="https://github.com/dsheval/dsh-top100/issues">问题反馈</a>
+</p>
 
 在 DeepSeek Harness Web 的设置页浏览中文榜单、搜索所需能力，并在核对来源、脚本与风险后确认安装。与官网共用榜单数据，无需自行运行采集器或数据库。
-
-[访问官网](https://www.dsheval.ai/) · [安装指南](https://www.dsheval.ai/?page=dsh#dsh) · [GitHub 源码](https://github.com/dsheval/dsh-top100) · [问题反馈](https://github.com/dsheval/dsh-top100/issues)
 
 ## 可以做什么
 

--- a/web/test/readme-contract.test.js
+++ b/web/test/readme-contract.test.js
@@ -11,7 +11,7 @@ const rawAssets = "https://raw.githubusercontent.com/dsheval/dsh-top100/main/web
 
 test("both READMEs introduce the same product and link to the installation guide", () => {
   for (const readme of [githubReadme, npmReadme]) {
-    assert.match(readme, /^# dsh-top100\b/);
+    assert.match(readme, /<h1 align="center">dsh-top100\b[^<]*<\/h1>/);
     assert.ok(readme.includes("https://www.dsheval.ai/?page=dsh#dsh"));
     assert.match(readme, /发现、安装和管理插件/);
     assert.match(readme, /Skills/);
@@ -52,7 +52,12 @@ test("GitHub and npm reference the same real screenshots using platform-safe pat
     }
   }
   for (const [, src] of npmReadme.matchAll(/<img\b[^>]*src="([^"]+)"/g)) {
-    assert.ok(src.startsWith(rawAssets), "npm screenshots must not depend on relative package files");
+    assert.ok(
+      src.startsWith(rawAssets)
+        || src === "https://raw.githubusercontent.com/dsheval/dsh-top100/main/docs/assets/dsh-top100-readme-cover.png"
+        || src.startsWith("https://img.shields.io/"),
+      "npm screenshots, cover and badges must use public absolute URLs",
+    );
   }
 });
 


### PR DESCRIPTION
恢复用户选定的 README 顶部样式：复用原横幅，居中展示标题、中英文简介、11 个徽章与官网入口；发布徽章更新为 v1.3.0。

GitHub 与 npm README 源文件统一布局，保留现有正文、安装说明及高清截图。npm 图片与文档链接使用公开绝对地址，线上 npm README 将随下次发版同步。本次不修改图片或包版本。

验证：4 项 README 契约检查及 `git diff --check` 通过；两份文档从“可以做什么”起的正文与截图引用逐字核对一致。GitHub Markdown 渲染预览中，横幅和全部徽章加载正常、标题居中、无横向溢出，用户已确认预览。

[GitHub README 预览](https://github.com/dsheval/dsh-top100/blob/docs/readme-centered-header/README.md) · [npm README 源文件预览](https://github.com/dsheval/dsh-top100/blob/docs/readme-centered-header/plugin/README.md)
