### PR TITLE
将 Top100 迁为主站子栏目、统一导航并精简 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -22,7 +27,10 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --no-audit --no-fund
+
+      - name: Audit all dependencies
+        run: npm run audit:security
 
       - name: Typecheck and test
         run: npm run check
@@ -36,5 +44,27 @@ jobs:
       - name: Validate Docker configuration
         run: docker compose config --quiet
 
-      - name: Build production images
-        run: docker compose build web scheduler
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build web image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/web.Dockerfile
+          load: true
+          push: false
+          tags: dsh-top100-web:ci
+          cache-from: type=gha,scope=dsh-top100-web
+          cache-to: type=gha,scope=dsh-top100-web,mode=max
+
+      - name: Build scheduler image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/collector.Dockerfile
+          load: true
+          push: false
+          tags: dsh-top100-scheduler:ci
+          cache-from: type=gha,scope=dsh-top100-scheduler
+          cache-to: type=gha,scope=dsh-top100-scheduler,mode=max

--- a/README.md
+++ b/README.md
@@ -1,34 +1,36 @@
 <p align="center">
-  <img src="./docs/assets/dsh-top100-readme-cover.png" alt="dsh-top100 · Verified DeepSeek Harness plugin rankings" width="100%">
+  <img src="./docs/assets/dsh-top100-readme-cover.png" alt="dsh-top100 · DSH-Eval plugin and Skills discovery" width="100%">
 </p>
 
 <h1 align="center">dsh-top100</h1>
 
 <p align="center">
-  <strong>发现、验证并追踪真正值得关注的 DeepSeek Harness 插件。</strong><br>
-  <sub>Verified DSH plugins ranked by GitHub signals, with Skills in a separate discovery directory.</sub>
+  <strong>DSH-Eval 旗下的插件与 Skills 发现栏目。</strong><br>
+  <sub>Discover DSH plugins and Skills with DSH-Eval, ranked by public GitHub signals.</sub>
 </p>
 
 <p align="center">
-  <a href="https://www.dsheval.ai"><img alt="在线体验" src="https://img.shields.io/badge/在线体验-Visit-5865f2?style=flat-square"></a>
+  <a href="https://dsheval.ai/top100/"><img alt="在线体验" src="https://img.shields.io/badge/在线体验-Visit-5865f2?style=flat-square"></a>
   <a href="https://github.com/dsheval/dsh-top100/releases/tag/v1.3.1"><img alt="正式版本 v1.3.1" src="https://img.shields.io/badge/release-v1.3.1-2f6f68?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@dsheval/dsh-top100-plugin"><img alt="npm latest" src="https://img.shields.io/npm/v/%40dsheval%2Fdsh-top100-plugin?style=flat-square&label=npm&color=cb3837"></a>
-  <a href="https://www.dsheval.ai/?page=dsh#dsh"><img alt="安装 dsh-top100" src="https://img.shields.io/badge/安装指南-接入_DSH-f2b84b?style=flat-square"></a>
+  <a href="https://dsheval.ai/top100/?page=dsh#dsh"><img alt="安装 dsh-top100" src="https://img.shields.io/badge/安装指南-接入_DSH-f2b84b?style=flat-square"></a>
   <a href="./CONTRIBUTING.md"><img alt="参与贡献" src="https://img.shields.io/badge/Contribute-参与贡献-555?style=flat-square&logo=github"></a>
   <a href="https://github.com/dsheval/dsh-top100/issues/new?labels=submission&title=%5BSubmit%5D%20owner%2Frepo"><img alt="提交插件" src="https://img.shields.io/badge/提交插件-Submit-2ea44f?style=flat-square"></a>
   <a href="https://github.com/dsheval/dsh-top100/stargazers"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/dsheval/dsh-top100?style=flat-square&logo=github&label=Stars"></a>
-  <a href="https://www.dsheval.ai/#ranking"><img alt="收录规模以实时榜单为准" src="https://img.shields.io/badge/收录-实时更新-5865f2?style=flat-square"></a>
+  <a href="https://dsheval.ai/top100/#ranking"><img alt="收录规模以实时榜单为准" src="https://img.shields.io/badge/收录-实时更新-5865f2?style=flat-square"></a>
   <a href="./LICENSE"><img alt="MIT License" src="https://img.shields.io/github/license/dsheval/dsh-top100?style=flat-square&label=License"></a>
   <a href="https://github.com/dsheval/dsh-top100/actions/workflows/ci.yml"><img alt="CI Status" src="https://img.shields.io/github/actions/workflow/status/dsheval/dsh-top100/ci.yml?branch=main&style=flat-square&label=CI"></a>
-  <a href="https://www.dsheval.ai"><img alt="每日 06:00 自动更新" src="https://img.shields.io/badge/每日自动更新-06%3A00-2ea44f?style=flat-square"></a>
+  <a href="https://dsheval.ai/top100/"><img alt="每日 06:00 自动更新" src="https://img.shields.io/badge/每日自动更新-06%3A00-2ea44f?style=flat-square"></a>
 </p>
 
 <p align="center">
   <strong>官方网站：</strong>
-  <a href="https://www.dsheval.ai"><strong>https://www.dsheval.ai</strong></a>
+  <a href="https://dsheval.ai/top100/"><strong>https://dsheval.ai/top100/</strong></a>
 </p>
 
 在官网浏览榜单，也可以把榜单带进 DSH，发现、安装和管理插件。综合热度、新锐榜和 Stars 总榜提供不同的比较视角；Skills 保持独立目录。
+
+Top100 是 [DSH-Eval](https://dsheval.ai/) 旗下的插件与 Skills 发现栏目；收录与排行依据公开项目信息，不代表项目已通过能力评测。评测结果与方法请访问 [DSH-Eval 主站](https://dsheval.ai/results)。
 
 ## 可以做什么
 
@@ -95,7 +97,7 @@ npx @deepseek-ai/dsh plugin --profile web add -w @dsheval/dsh-top100-plugin@1.3.
 
 </details>
 
-打开 DSH Web，进入 **设置 → 插件排行**。安装和启动必须使用同一种命令前缀；全局 CLI、源码运行及问题排查见 [安装指南](https://www.dsheval.ai/?page=dsh#dsh)。
+打开 DSH Web，进入 **设置 → 插件排行**。安装和启动必须使用同一种命令前缀；全局 CLI、源码运行及问题排查见 [安装指南](https://dsheval.ai/top100/?page=dsh#dsh)。
 
 这里只安装榜单插件，不会自动安装榜单中的其他项目。安装其他插件前，仍需核对来源、脚本与风险；安装后按提示重启 DSH 并检查运行状态。
 

--- a/docker/collector.Dockerfile
+++ b/docker/collector.Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 COPY collector/package.json collector/package.json
 COPY schema/package.json schema/package.json
-RUN npm ci
+# CI audits the full lockfile before building; keep network audits outside cached layers.
+RUN npm ci --no-audit --no-fund
 
 COPY collector collector
 COPY schema schema

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -62,7 +62,7 @@ origin  https://github.com/dsheval/dsh-top100.git
 - 首页使用白色与中性鼠尾草绿分层，深绿承担交互状态。
 - Hero 区包含全库搜索、插件榜单与安装入口；右侧恢复发布信息卡片，展示 npm 版本、DSH Web 兼容版本、来源与复制命令。星环暂时移除，后续再单独决定是否以及如何融入。
 - `安装指南` 切换到单列操作页：版本前提 → 安装插件 → 启动 DSH Web → 设置中的「插件排行」。只在该视图隐藏首页 Hero，点击品牌标志返回首页。
-- `DSHeval` 按钮直接打开 `https://www.dsheval.ai/dsheval`。
+- DSH-Eval 主导航指向主站 `/`、`/results`、`/methodology`、`/faq`；Top100 栏目位于 `/top100/`。
 - `GitHub` 直达 `https://github.com/dsheval/dsh-top100`。
 - 榜单滚动进入视口时按从上到下的顺序显示动画。
 
@@ -73,7 +73,7 @@ origin  https://github.com/dsheval/dsh-top100.git
 - Docs 内有“返回榜单”按钮，浏览器前进、后退和刷新可以恢复当前视图。
 - `web/public/docs.html` 是文档内容源；`index.html` 读取其中的 `.docs-layout` 并嵌入首页，因此不要复制出第二套文档正文。
 - 独立访问 `/docs.html` 仍可作为直接文档地址和同页加载失败时的内容源。
-- `web/public/dsh.html` 和 `web/public/dsheval.html` 是同页加载的内容片段；前者为接入说明，后者用于承接后续 DSHeval 页面材料。
+- `web/public/dsh.html` 和 `web/public/dsheval.html` 是同页加载的内容片段；前者为接入说明，后者说明 DSH-Eval 与 Top100 的关系并链接正式评测主站。
 - DSH 插件随包提供 `recommend-dsh-plugins` Skill，并注册 `dsh_top100_search` 只读模型工具；对话中的插件推荐直接查询同一份实时榜单和共享智能搜索逻辑。
 - DSH 插件设置页增加「插件市场 / 已安装 / 诊断」三层导航；分类仍统一使用 Agent增强、外观、编程、知识、工具、安全，管理操作通过同源 Host API 和 profile 串行队列执行。
 
@@ -115,7 +115,7 @@ origin  https://github.com/dsheval/dsh-top100.git
 web/public/index.html       首页、榜单、多内容页切换、全部样式和前端逻辑
 web/public/docs.html        最新 Docs 正文内容源及独立文档页面
 web/public/dsh.html         接入 DSH 页面正文
-web/public/dsheval.html     DSHeval 页面占位正文
+web/public/dsheval.html     DSH-Eval 主站介绍与入口
 web/public/data/            镜像构建时的静态数据目录
 runtime/public-data/        Docker Web 容器实际只读挂载的公开榜单 JSON
 docker/nginx.conf           静态站点与 /data 路由
@@ -205,7 +205,7 @@ DSH_DISCOVERY_MODE=incremental
 npm run serve
 ```
 
-默认地址为 `http://127.0.0.1:4173/`。可使用 `WEB_PORT` 修改端口，或用
+默认地址为 `http://127.0.0.1:4173/top100/`。可使用 `WEB_PORT` 修改端口，或用
 `DSH_DATA_ORIGIN` 指定另一套兼容的公开数据服务。完全不需要榜单数据的静态检查
 仍可运行 `npm run serve:static`。
 
@@ -291,3 +291,7 @@ docker compose down
 - 不要 SSH 到 `47.238.229.20`，除非用户在服务器专用任务中明确授权。
 - 不要自动推送 GitHub；只有用户明确要求时才提交和推送。
 - 不要把 `.env`、SQLite、`runtime/`、备份文件或 API Key 加入 Git。
+
+## 全站页头与页脚统一（本地待发布）
+
+DSH-Eval 与 Top100 共用 DSH / EVAL 字标、单层固定页头、移动端菜单和浅色页脚。品牌标志返回全站 `/`；正文中的 Top100 栏目标题返回榜单，栏目标签随内容滚动。两仓库 `site-chrome.css` 保持逐字节一致，修改时同步。页脚固定提供评测源码、Top100 源码和常见问题，数据来源说明放在榜单附近。

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -13,6 +13,23 @@ high-Star repositories within `DEEPSEEK_SUMMARY_BATCH_SIZE`; tune
 `DEEPSEEK_SUMMARY_ATTEMPTS`, `DEEPSEEK_SUMMARY_TIMEOUT_MS` and
 `DEEPSEEK_SUMMARY_CONCURRENCY` for the API quota available on the deployment.
 
+## CI checks
+
+CI runs for pull requests and pushes to `main`; a new commit cancels the older
+run for the same ref. Branch pushes and release tags do not start duplicate CI.
+Before releasing a tag, verify the tagged commit passed the `main` checks.
+
+Dependency installation uses `npm ci --no-audit --no-fund`. A separate
+`npm run audit:security` checks the complete dependency tree once per run and
+blocks on high/critical findings or audit errors. Each audit request has a
+five-minute timeout and one retry. Docker builds do not repeat this audit;
+manual releases must also have a successful audit for the target commit.
+
+Typechecks, all tests, runtime publication and Compose validation are retained.
+Both web and scheduler images are built using separate GitHub Actions cache
+scopes, loaded locally on the runner and never pushed. No path-based skipping
+is enabled in this first optimization pass.
+
 ## First deployment
 
 ```bash
@@ -96,3 +113,31 @@ Run `./scripts/backup-runtime.sh` before application upgrades and on a regular s
 - Expose only the Web port; do not expose SQLite or the scheduler container.
 - Enable HTTPS and security updates on the host.
 - Keep `RUN_COLLECT_ON_STARTUP=false` unless an immediate network collection is intended.
+
+## Public site mount
+
+DSH-Eval owns `https://dsheval.ai/`. Top100 is mounted at
+`https://dsheval.ai/top100/`; the outer Caddy gateway strips `/top100` before
+proxying to this repository's `web:80`. Nginx continues to serve files from its
+root, so direct container smoke checks at `http://127.0.0.1:8080/` remain valid.
+Use `npm run serve` and `http://127.0.0.1:4173/top100/` for the browser preview.
+
+The gateway must keep `/data/*` and `/api/events` routed to Top100. Released
+plugins continue to use `https://www.dsheval.ai/data`; keep that endpoint working
+without a redirect to a different host. Manifest snapshot URLs are absolute
+paths under `/data/`, independent of the website mount. DSH-Eval report downloads
+use `/eval-data/` to avoid collisions.
+
+The main site's robots and sitemap must advertise the Top100 sitemap at
+`https://dsheval.ai/top100/sitemap.xml`. Existing root HTML links redirect to their
+matching `/top100/` pages with query parameters and fragments preserved by the
+gateway/browser. Root query/hash links are handled by the DSH-Eval landing page.
+
+Repository About and npm public metadata should use:
+- Website: `https://dsheval.ai/top100/`
+- Repository description: `DSH-Eval 旗下的插件与 Skills 发现栏目，按公开 GitHub 信号持续更新。`
+- npm metadata and README: prepared in `plugin/package.json` and `plugin/README.md`;
+  they become public with the next explicitly authorized package release.
+
+Updating repository About, publishing npm, and deploying the gateway are separate
+external actions; local changes do not apply those updates automatically.

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "version": "1.3.1",
   "private": true,
   "type": "module",
-  "description": "Verified DeepSeek Harness plugin rankings with daily GitHub updates",
+  "description": "DSH-Eval plugin and Skills discovery with daily GitHub rankings",
   "workspaces": [
     "schema",
     "collector",
     "plugin"
   ],
   "scripts": {
+    "audit:security": "npm audit --audit-level=high --fetch-retries=1 --fetch-timeout=300000",
     "check": "npm run version:check && npm run search:build && npm run typecheck && npm test",
     "version:sync": "node scripts/sync-install-version.mjs",
     "version:check": "node scripts/sync-install-version.mjs --check",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/dsheval/dsh-top100/main/docs/assets/dsh-top100-readme-cover.png" alt="dsh-top100 · Verified DeepSeek Harness plugin rankings" width="100%">
+  <img src="https://raw.githubusercontent.com/dsheval/dsh-top100/main/docs/assets/dsh-top100-readme-cover.png" alt="dsh-top100 · DSH-Eval plugin and Skills discovery" width="100%">
 </p>
 
 <h1 align="center">dsh-top100 · DSH 插件</h1>
@@ -10,22 +10,22 @@
 </p>
 
 <p align="center">
-  <a href="https://www.dsheval.ai"><img alt="在线体验" src="https://img.shields.io/badge/在线体验-Visit-5865f2?style=flat-square"></a>
+  <a href="https://dsheval.ai/top100/"><img alt="在线体验" src="https://img.shields.io/badge/在线体验-Visit-5865f2?style=flat-square"></a>
   <a href="https://github.com/dsheval/dsh-top100/releases/tag/v1.3.1"><img alt="正式版本 v1.3.1" src="https://img.shields.io/badge/release-v1.3.1-2f6f68?style=flat-square"></a>
   <a href="https://www.npmjs.com/package/@dsheval/dsh-top100-plugin"><img alt="npm latest" src="https://img.shields.io/npm/v/%40dsheval%2Fdsh-top100-plugin?style=flat-square&label=npm&color=cb3837"></a>
-  <a href="https://www.dsheval.ai/?page=dsh#dsh"><img alt="安装 dsh-top100" src="https://img.shields.io/badge/安装指南-接入_DSH-f2b84b?style=flat-square"></a>
+  <a href="https://dsheval.ai/top100/?page=dsh#dsh"><img alt="安装 dsh-top100" src="https://img.shields.io/badge/安装指南-接入_DSH-f2b84b?style=flat-square"></a>
   <a href="https://github.com/dsheval/dsh-top100/blob/main/CONTRIBUTING.md"><img alt="参与贡献" src="https://img.shields.io/badge/Contribute-参与贡献-555?style=flat-square&logo=github"></a>
   <a href="https://github.com/dsheval/dsh-top100/issues/new?labels=submission&title=%5BSubmit%5D%20owner%2Frepo"><img alt="提交插件" src="https://img.shields.io/badge/提交插件-Submit-2ea44f?style=flat-square"></a>
   <a href="https://github.com/dsheval/dsh-top100/stargazers"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/dsheval/dsh-top100?style=flat-square&logo=github&label=Stars"></a>
-  <a href="https://www.dsheval.ai/#ranking"><img alt="收录规模以实时榜单为准" src="https://img.shields.io/badge/收录-实时更新-5865f2?style=flat-square"></a>
+  <a href="https://dsheval.ai/top100/#ranking"><img alt="收录规模以实时榜单为准" src="https://img.shields.io/badge/收录-实时更新-5865f2?style=flat-square"></a>
   <a href="https://github.com/dsheval/dsh-top100/blob/main/LICENSE"><img alt="MIT License" src="https://img.shields.io/github/license/dsheval/dsh-top100?style=flat-square&label=License"></a>
   <a href="https://github.com/dsheval/dsh-top100/actions/workflows/ci.yml"><img alt="CI Status" src="https://img.shields.io/github/actions/workflow/status/dsheval/dsh-top100/ci.yml?branch=main&style=flat-square&label=CI"></a>
-  <a href="https://www.dsheval.ai"><img alt="每日 06:00 自动更新" src="https://img.shields.io/badge/每日自动更新-06%3A00-2ea44f?style=flat-square"></a>
+  <a href="https://dsheval.ai/top100/"><img alt="每日 06:00 自动更新" src="https://img.shields.io/badge/每日自动更新-06%3A00-2ea44f?style=flat-square"></a>
 </p>
 
 <p align="center">
   <strong>官方网站：</strong>
-  <a href="https://www.dsheval.ai"><strong>https://www.dsheval.ai</strong></a>
+  <a href="https://dsheval.ai/top100/"><strong>https://dsheval.ai/top100/</strong></a>
 </p>
 
 <p align="center">
@@ -33,6 +33,8 @@
 </p>
 
 在 DeepSeek Harness Web 的设置页浏览中文榜单、搜索所需能力，并在核对来源、脚本与风险后确认安装。与官网共用榜单数据，无需自行运行采集器或数据库。
+
+Top100 是 [DSH-Eval](https://dsheval.ai/) 旗下的插件与 Skills 发现栏目；收录与排行依据公开项目信息，不代表项目已通过能力评测。评测结果与方法请访问 [DSH-Eval 主站](https://dsheval.ai/results)。
 
 ## 可以做什么
 
@@ -150,7 +152,7 @@ dsh web
 
 </details>
 
-更多操作说明见 [官网安装指南](https://www.dsheval.ai/?page=dsh#dsh)。
+更多操作说明见 [官网安装指南](https://dsheval.ai/top100/?page=dsh#dsh)。
 
 ## 数据源
 

--- a/plugin/client/client.js
+++ b/plugin/client/client.js
@@ -48,7 +48,7 @@ function cleanDescription(value) {
 	return String(value ?? "").replace(/```[\s\S]*?```/g, " ").replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, " ").replace(/<[^>]*>/g, " ").replace(/!\[[^\]]*\]\([^)]*\)/g, " ").replace(/\[([^\]]+)\]\([^)]*\)/g, "$1").replace(/&nbsp;|&#160;/gi, " ").replace(/&amp;/gi, "&").replace(/[`*_~>#]/g, " ").replace(/\s+/g, " ").trim();
 }
 function isPlaceholder(value) {
-	return !value || /资料不足|暂无.*简介|简介正在生成|用于扩展 DeepSeek Harness 能力|请(?:查看|参考).*(?:README|项目说明|项目文档)|求\s*Star|留颗\s*Star|顺手.*Star|欢迎.*(?:使用|贡献)|\|.*\|/i.test(value);
+	return !value || /^(?:版本更新提示[：:]|本次版本变化较大|较早的.+宿主请使用|[-\s🚨【]*国内用户核心前置)/u.test(value) || /资料不足|暂无.*简介|简介正在生成|用于扩展 DeepSeek Harness 能力|请(?:查看|参考).*(?:README|项目说明|项目文档)|求\s*Star|留颗\s*Star|顺手.*Star|欢迎.*(?:使用|贡献)|\|.*\|/i.test(value);
 }
 function descriptionFor(entry, reviewed = {}, context = {}) {
 	const review = reviewed[String(entry.fullName || "").toLowerCase()];
@@ -751,7 +751,7 @@ const SORT_VIEWS = [
 ];
 const CATALOG_SCOPES = ["plugins", "skills"];
 const LAST_BATCH_KEY = "dsh-top100:last-install-batch:v1";
-const DSHEVAL_SITE = "https://www.dsheval.ai";
+const DSHEVAL_SITE = "https://dsheval.ai/top100/";
 const GITHUB_ICON = /* @__PURE__ */ (0, react_jsx_runtime.jsx)("svg", {
 	viewBox: "0 0 24 24",
 	"aria-hidden": "true",
@@ -1298,7 +1298,7 @@ function RankingsPage({ t }) {
 										target: "_blank",
 										rel: "noreferrer",
 										title: data.dataUrl,
-										children: "DSHEval"
+										children: "DSH-Eval Top100"
 									})
 								] }),
 								/* @__PURE__ */ (0, react_jsx_runtime.jsxs)("span", { children: [

--- a/plugin/lib/host/recommendations.d.ts
+++ b/plugin/lib/host/recommendations.d.ts
@@ -4,7 +4,7 @@ import type { PluginCategoryId, RankingsDocument } from "../shared/types.js";
 import type { PluginResolvedConfig } from "./contracts.js";
 export declare const RECOMMENDATION_SKILL_NAME = "recommend-dsh-plugins";
 export declare const RECOMMENDATION_TOOL_NAME = "dsh_top100_search";
-export declare const DSHEVAL_CATALOG_URL = "https://www.dsheval.ai/#ranking";
+export declare const DSHEVAL_CATALOG_URL = "https://dsheval.ai/top100/#ranking";
 export interface RecommendationItem {
     rank: number;
     fullName: string;

--- a/plugin/lib/host/recommendations.js
+++ b/plugin/lib/host/recommendations.js
@@ -8,7 +8,7 @@ import { filterCatalog, loadSearchRankings } from "./catalog.js";
 import { readInstalled } from "./profile.js";
 export const RECOMMENDATION_SKILL_NAME = "recommend-dsh-plugins";
 export const RECOMMENDATION_TOOL_NAME = "dsh_top100_search";
-export const DSHEVAL_CATALOG_URL = "https://www.dsheval.ai/#ranking";
+export const DSHEVAL_CATALOG_URL = "https://dsheval.ai/top100/#ranking";
 const PROVIDER_NAME = "dsh-top100";
 const DEFAULT_LIMIT = 5;
 const MAX_LIMIT = 10;

--- a/plugin/lib/shared/description-rules.js
+++ b/plugin/lib/shared/description-rules.js
@@ -12,7 +12,7 @@ export function cleanDescription(value) {
         .replace(/\s+/g, ' ').trim();
 }
 export function isPlaceholder(value) {
-    return !value || /资料不足|暂无.*简介|简介正在生成|用于扩展 DeepSeek Harness 能力|请(?:查看|参考).*(?:README|项目说明|项目文档)|求\s*Star|留颗\s*Star|顺手.*Star|欢迎.*(?:使用|贡献)|\|.*\|/i.test(value);
+    return !value || /^(?:版本更新提示[：:]|本次版本变化较大|较早的.+宿主请使用|[-\s🚨【]*国内用户核心前置)/u.test(value) || /资料不足|暂无.*简介|简介正在生成|用于扩展 DeepSeek Harness 能力|请(?:查看|参考).*(?:README|项目说明|项目文档)|求\s*Star|留颗\s*Star|顺手.*Star|欢迎.*(?:使用|贡献)|\|.*\|/i.test(value);
 }
 export function descriptionFor(entry, reviewed = {}, context = {}) {
     const review = reviewed[String(entry.fullName || '').toLowerCase()];

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@dsheval/dsh-top100-plugin",
   "version": "1.3.1",
-  "description": "dsh-top100 rankings inside DeepSeek Harness Settings",
+  "description": "Discover, install and manage DSH-Eval Top100 plugins and Skills in DeepSeek Harness",
   "type": "module",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "MIT",
-  "homepage": "https://www.dsheval.ai/",
+  "homepage": "https://dsheval.ai/top100/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/dsheval/dsh-top100.git",

--- a/plugin/src/client/RankingsPage.tsx
+++ b/plugin/src/client/RankingsPage.tsx
@@ -35,7 +35,7 @@ interface RankingsPageProps {
 const SORT_VIEWS: RankingView[] = ["hot", "rising", "total"];
 const CATALOG_SCOPES: CatalogScope[] = ["plugins", "skills"];
 const LAST_BATCH_KEY = "dsh-top100:last-install-batch:v1";
-const DSHEVAL_SITE = "https://www.dsheval.ai";
+const DSHEVAL_SITE = "https://dsheval.ai/top100/";
 type PageSection = "rankings" | "installed" | "diagnostics";
 const GITHUB_ICON = (
   <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
@@ -537,7 +537,7 @@ export function RankingsPage({ t }: RankingsPageProps) {
                 {t("updated")} {data.snapshotDate}
               </span>
               <span>
-                {t("source")} <a className="data-source" href={DSHEVAL_SITE} target="_blank" rel="noreferrer" title={data.dataUrl}>DSHEval</a>
+                {t("source")} <a className="data-source" href={DSHEVAL_SITE} target="_blank" rel="noreferrer" title={data.dataUrl}>DSH-Eval Top100</a>
               </span>
               <span>{data.total} {t("entries")}</span>
               <span title={data.cache.fetchedAt ? new Date(data.cache.fetchedAt).toLocaleString() : undefined}>

--- a/plugin/src/host/recommendations.ts
+++ b/plugin/src/host/recommendations.ts
@@ -18,7 +18,7 @@ import { readInstalled } from "./profile.js";
 
 export const RECOMMENDATION_SKILL_NAME = "recommend-dsh-plugins";
 export const RECOMMENDATION_TOOL_NAME = "dsh_top100_search";
-export const DSHEVAL_CATALOG_URL = "https://www.dsheval.ai/#ranking";
+export const DSHEVAL_CATALOG_URL = "https://dsheval.ai/top100/#ranking";
 const PROVIDER_NAME = "dsh-top100";
 const DEFAULT_LIMIT = 5;
 const MAX_LIMIT = 10;

--- a/plugin/src/shared/description-rules.ts
+++ b/plugin/src/shared/description-rules.ts
@@ -27,7 +27,7 @@ export function cleanDescription(value: unknown): string {
     .replace(/\s+/g, ' ').trim();
 }
 export function isPlaceholder(value: string): boolean {
-  return !value || /资料不足|暂无.*简介|简介正在生成|用于扩展 DeepSeek Harness 能力|请(?:查看|参考).*(?:README|项目说明|项目文档)|求\s*Star|留颗\s*Star|顺手.*Star|欢迎.*(?:使用|贡献)|\|.*\|/i.test(value);
+  return !value || /^(?:版本更新提示[：:]|本次版本变化较大|较早的.+宿主请使用|[-\s🚨【]*国内用户核心前置)/u.test(value) || /资料不足|暂无.*简介|简介正在生成|用于扩展 DeepSeek Harness 能力|请(?:查看|参考).*(?:README|项目说明|项目文档)|求\s*Star|留颗\s*Star|顺手.*Star|欢迎.*(?:使用|贡献)|\|.*\|/i.test(value);
 }
 export function descriptionFor(entry: DescriptionEntry, reviewed: ReviewedDescriptions = {}, context: DescriptionContext = {}): string {
   const review = reviewed[String(entry.fullName || '').toLowerCase()];

--- a/scripts/serve-dev.mjs
+++ b/scripts/serve-dev.mjs
@@ -18,6 +18,8 @@ const mimeTypes = new Map([
   [".png", "image/png"],
   [".svg", "image/svg+xml"],
   [".txt", "text/plain; charset=utf-8"],
+  [".xml", "application/xml; charset=utf-8"],
+  [".jpg", "image/jpeg"],
 ]);
 
 function proxyData(request, response) {
@@ -74,7 +76,21 @@ const server = createServer((request, response) => {
     return response.end();
   }
 
-  const path = localFileFor(requestUrl.pathname) ?? join(publicRoot, "index.html");
+  // Match the public /top100/ mount while keeping /data/ and /api/events at root.
+  if (requestUrl.pathname === "/" || requestUrl.pathname === "/top100" ||
+      (!requestUrl.pathname.startsWith("/top100/") && localFileFor(requestUrl.pathname))) {
+    const suffix = requestUrl.pathname === "/" || requestUrl.pathname === "/top100"
+      ? "/" : requestUrl.pathname;
+    response.writeHead(308, { location: `/top100${suffix}${requestUrl.search}` });
+    return response.end();
+  }
+  const relativePath = requestUrl.pathname.startsWith("/top100/")
+    ? requestUrl.pathname.slice("/top100".length) : null;
+  const path = relativePath && localFileFor(relativePath === "/" ? "/index.html" : relativePath);
+  if (!path) {
+    response.writeHead(404, { "content-type": "text/plain; charset=utf-8" });
+    return response.end("Not found. This preview serves Top100 at /top100/.\n");
+  }
   response.writeHead(200, {
     "cache-control": "no-cache",
     "content-type": mimeTypes.get(extname(path)) ?? "application/octet-stream",
@@ -84,6 +100,6 @@ const server = createServer((request, response) => {
 });
 
 server.listen(port, "127.0.0.1", () => {
-  console.log(`Local preview: http://127.0.0.1:${port}/`);
+  console.log(`Local preview: http://127.0.0.1:${server.address().port}/top100/`);
   console.log(`Ranking data: ${dataOrigin.origin}/data/`);
 });

--- a/web/public/assets/dsh-top100-mark.svg
+++ b/web/public/assets/dsh-top100-mark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="dsh-top100">
+  <path d="M12 37 21 42.5 36 17l-9-5.5Z" fill="#2f6f68"/>
+  <path d="m34 30 9-5.5L57 46l-9 5.5Z" fill="#2f6f68"/>
+</svg>

--- a/web/public/description-rules.js
+++ b/web/public/description-rules.js
@@ -3,7 +3,7 @@ function cleanDescription(value) {
   return String(value ?? "").replace(/```[\s\S]*?```/g, " ").replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1>/gi, " ").replace(/<[^>]*>/g, " ").replace(/!\[[^\]]*\]\([^)]*\)/g, " ").replace(/\[([^\]]+)\]\([^)]*\)/g, "$1").replace(/&nbsp;|&#160;/gi, " ").replace(/&amp;/gi, "&").replace(/[`*_~>#]/g, " ").replace(/\s+/g, " ").trim();
 }
 function isPlaceholder(value) {
-  return !value || /资料不足|暂无.*简介|简介正在生成|用于扩展 DeepSeek Harness 能力|请(?:查看|参考).*(?:README|项目说明|项目文档)|求\s*Star|留颗\s*Star|顺手.*Star|欢迎.*(?:使用|贡献)|\|.*\|/i.test(value);
+  return !value || /^(?:版本更新提示[：:]|本次版本变化较大|较早的.+宿主请使用|[-\s🚨【]*国内用户核心前置)/u.test(value) || /资料不足|暂无.*简介|简介正在生成|用于扩展 DeepSeek Harness 能力|请(?:查看|参考).*(?:README|项目说明|项目文档)|求\s*Star|留颗\s*Star|顺手.*Star|欢迎.*(?:使用|贡献)|\|.*\|/i.test(value);
 }
 function descriptionFor(entry, reviewed = {}, context = {}) {
   const review = reviewed[String(entry.fullName || "").toLowerCase()];

--- a/web/public/docs.html
+++ b/web/public/docs.html
@@ -7,7 +7,7 @@
       name="description"
       content="dsh-top100 文档：了解插件收录、智能分类、DSH 接入、Top 100 评分和每日数据更新。"
     />
-    <title>Docs · dsh-top100</title>
+    <title>排名方法 · Top100 · DSH-Eval</title>
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <style>
       :root {
@@ -102,6 +102,7 @@
       }
 
       .docs-hero {
+        --site-copy-color: #c7d8d3;
         position: relative;
         isolation: isolate;
         min-height: 440px;
@@ -603,7 +604,7 @@
     </style>
     <link rel="stylesheet" href="./site-controls.css?v=20260905-nav2" />
     <link rel="canonical" href="https://dsheval.ai/top100/?page=docs" />
-    <link rel="stylesheet" href="./site-chrome.css?v=20260905-nav2" />
+    <link rel="stylesheet" href="./site-chrome.css?v=20260905-type8c" />
   </head>
   <body>
     <header class="dsh-site-header">
@@ -632,7 +633,7 @@
     <header class="docs-hero">
       <div class="docs-hero-inner">
         <h1>排名方法</h1>
-        <p class="docs-title-zh">榜单、分类与 DSH 插件。</p>
+        <p class="docs-title-zh" data-site-copy="lead">榜单、分类与 DSH 插件。</p>
       </div>
       <div class="orbit" aria-hidden="true"></div>
     </header>
@@ -650,47 +651,47 @@
 
       <article class="docs-content">
         <section class="doc-section" id="overview">
-          <p class="section-kicker">01 · Overview</p>
+          <p class="section-kicker" data-site-label="section" lang="en">01 · Overview</p>
           <h2>三个榜单与分类筛选</h2>
-          <p class="lead">
+          <p class="lead" data-site-copy="body">
             dsh-top100 帮助你发现 DSH 插件、比较项目热度并找到安装入口。排名单位是 GitHub 仓库；Skills 单独展示。收录检查确认项目与 DSH 的关联证据，不代表已安装验证、通过能力评测或安全审计。
           </p>
           <div class="card-grid four">
             <article class="doc-card">
-              <span class="card-label">Composite signal</span>
+              <span class="card-label" data-site-label="section" lang="en">Composite signal</span>
               <h3>Top 100</h3>
-              <p>综合日增、周增、增长率、活跃度、数据质量和总 Stars，发现当前最值得关注的项目。</p>
+              <p data-site-copy="body">综合日增、周增、增长率、活跃度、数据质量和总 Stars，发现当前最值得关注的项目。</p>
             </article>
             <article class="doc-card">
-              <span class="card-label">Daily momentum</span>
+              <span class="card-label" data-site-label="section" lang="en">Daily momentum</span>
               <h3>新锐榜</h3>
-              <p>当前 Stars 减去上一份每日快照，按今日新增 Stars 排序，负增长按 0 处理。</p>
+              <p data-site-copy="body">当前 Stars 减去上一份每日快照，按今日新增 Stars 排序，负增长按 0 处理。</p>
             </article>
             <article class="doc-card">
-              <span class="card-label">All verified</span>
+              <span class="card-label" data-site-label="section" lang="en">All verified</span>
               <h3>总榜</h3>
-              <p>展示全部活跃且符合收录规则的插件仓库，按当前 GitHub Stars 总数降序排列。</p>
+              <p data-site-copy="body">展示全部活跃且符合收录规则的插件仓库，按当前 GitHub Stars 总数降序排列。</p>
             </article>
             <article class="doc-card">
-              <span class="card-label">README semantics</span>
+              <span class="card-label" data-site-label="section" lang="en">README semantics</span>
               <h3>分类筛选</h3>
-              <p>在综合热度、新锐或 Stars 排序下，按用途进一步筛选；同一插件可以属于多个分类。</p>
+              <p data-site-copy="body">在综合热度、新锐或 Stars 排序下，按用途进一步筛选；同一插件可以属于多个分类。</p>
             </article>
           </div>
           <h3>README 智能分类</h3>
-          <p>
+          <p data-site-copy="body">
             DeepSeek 根据 README、描述和 topics 选择一个主分类，再补充一至两个有明确依据的相关分类。
             同一项目可能属于多个分类，所以分类数量相加可能大于项目总数。模型不可用时，使用基于项目资料的规则分类。
           </p>
         </section>
 
         <section class="doc-section" id="plugin">
-          <p class="section-kicker">02 · DSH Plugin</p>
+          <p class="section-kicker" data-site-label="section" lang="en">02 · DSH Plugin</p>
           <h2>排行榜也可以直接进入 DSH</h2>
-          <p class="lead">安装 dsh-top100 后，可以在 DSH 设置页浏览、搜索榜单，并复制或确认运行项目提供的安装命令。</p>
-          <p>插件与网站共用线上榜单。安装来源可以解析，不代表已经实际安装验证；运行前仍需核对项目说明、宿主版本和所需权限。</p>
-          <p><a href="./?page=dsh#dsh">查看安装指南 →</a></p>
-          <p>
+          <p class="lead" data-site-copy="body">安装 dsh-top100 后，可以在 DSH 设置页浏览、搜索榜单，并复制或确认运行项目提供的安装命令。</p>
+          <p data-site-copy="body">插件与网站共用线上榜单。安装来源可以解析，不代表已经实际安装验证；运行前仍需核对项目说明、宿主版本和所需权限。</p>
+          <p data-site-copy="body"><a href="./?page=dsh#dsh">查看安装指南 →</a></p>
+          <p data-site-copy="body">
             安装包还内置 <code>recommend-dsh-plugins</code> Skill，并注册只读的
             <code>dsh_top100_search</code> 搜索工具。当用户在 DSH 对话中询问“该装哪个插件”或描述所需能力时，
             DSH 会加载该 Skill，从实时 Top100 插件市场检索并给出有榜单数据依据的推荐。
@@ -698,9 +699,9 @@
         </section>
 
         <section class="doc-section" id="discovery">
-          <p class="section-kicker">03 · Discovery</p>
+          <p class="section-kicker" data-site-label="section" lang="en">03 · Discovery</p>
           <h2>如何尽可能完整地发现仓库</h2>
-          <p class="lead">
+          <p class="lead" data-site-copy="body">
             系统从多个公开来源发现候选项目，再按同一套收录规则筛选。自动发现可能有遗漏，收录范围以当日快照为准。
           </p>
           <div class="pipeline" aria-label="数据处理流程">
@@ -711,18 +712,18 @@
             <span>公开榜单 JSON</span>
           </div>
           <ol class="rule-list">
-            <li><strong>Repository Search：</strong>搜索 DSH 名称、描述、README 与 topics。</li>
-            <li><strong>Code Search：</strong>寻找 <code>SKILL.md</code>、DSH/Cordis 配置和依赖等强结构标记。</li>
-            <li><strong>生态来源：</strong>补充 npm、Awesome 列表、相关组织仓库、历史目录和用户提交。</li>
-            <li><strong>递归分片：</strong>每周完整发现按创建时间切分，必要时再按 Stars 和仓库大小切分，避免 GitHub 单次搜索 1,000 条结果上限造成静默遗漏。</li>
-            <li><strong>稳定去重：</strong>优先使用 GitHub repository ID；同一仓库从多个来源命中时合并并保留全部来源证据。</li>
+            <li data-site-copy="body"><strong>Repository Search：</strong>搜索 DSH 名称、描述、README 与 topics。</li>
+            <li data-site-copy="body"><strong>Code Search：</strong>寻找 <code>SKILL.md</code>、DSH/Cordis 配置和依赖等强结构标记。</li>
+            <li data-site-copy="body"><strong>生态来源：</strong>补充 npm、Awesome 列表、相关组织仓库、历史目录和用户提交。</li>
+            <li data-site-copy="body"><strong>递归分片：</strong>每周完整发现按创建时间切分，必要时再按 Stars 和仓库大小切分，避免 GitHub 单次搜索 1,000 条结果上限造成静默遗漏。</li>
+            <li data-site-copy="body"><strong>稳定去重：</strong>优先使用 GitHub repository ID；同一仓库从多个来源命中时合并并保留全部来源证据。</li>
           </ol>
         </section>
 
         <section class="doc-section" id="verification">
-          <p class="section-kicker">04 · Verification</p>
+          <p class="section-kicker" data-site-label="section" lang="en">04 · Verification</p>
           <h2>什么仓库可以入榜</h2>
-          <p class="lead">
+          <p class="lead" data-site-copy="body">
             名称、标签和关键词用于发现候选项目，不能单独证明兼容性。候选仓库还需提供 DSH 插件、Skill、Bundle 或 Cordis 集成等结构证据；这些检查不等同于实际运行测试。
           </p>
           <div class="table-wrap">
@@ -761,9 +762,9 @@
         </section>
 
         <section class="doc-section" id="ranking">
-          <p class="section-kicker">05 · Ranking</p>
+          <p class="section-kicker" data-site-label="section" lang="en">05 · Ranking</p>
           <h2>Top 100 如何计算</h2>
-          <p class="lead">
+          <p class="lead" data-site-copy="body">
             Top 100 使用 100 分加权模型，按综合热度排序并显示一位小数。
             新锐榜显示今日新增 Stars，总榜显示 GitHub Stars 总数。
           </p>
@@ -787,21 +788,21 @@
             </table>
           </div>
           <div class="formula">TopScore = 日增×35 + 周增×25 + 增长率×15 + 活跃度×10 + 数据质量×10 + 总热度×5</div>
-          <p>
+          <p data-site-copy="body">
             Stars 增长和总热度使用对数归一化，避免一个超大型仓库压缩其余项目的分数差异。综合分相同时，
             依次比较今日新增 Stars、当前 Stars 和仓库全名。
           </p>
         </section>
 
         <section class="doc-section" id="database">
-          <p class="section-kicker">06 · Persistence</p>
+          <p class="section-kicker" data-site-label="section" lang="en">06 · Persistence</p>
           <h2>数据何时更新</h2>
-          <p class="lead">计划在北京时间每天 06:00 开始更新，每周日进行更完整的仓库发现。采集需要时间，页面上显示的快照时间才是本次数据的实际更新时间。</p>
+          <p class="lead" data-site-copy="body">计划在北京时间每天 06:00 开始更新，每周日进行更完整的仓库发现。采集需要时间，页面上显示的快照时间才是本次数据的实际更新时间。</p>
           <h3>为什么数据可能暂时没有变化</h3>
-          <p>GitHub 请求限制、网络异常或采集失败可能延迟更新。新快照生成成功后才发布；更新未完成时继续提供上次有效数据。</p>
+          <p data-site-copy="body">GitHub 请求限制、网络异常或采集失败可能延迟更新。新快照生成成功后才发布；更新未完成时继续提供上次有效数据。</p>
           <h3>简介与分类如何更新</h3>
-          <p>简介和分类依据公开项目资料整理。缺少可用的中文简介时保留项目原文；项目资料发生变化后，旧的人工整理内容可能失效并等待重新核对。</p>
-          <p><a href="https://github.com/dsheval/dsh-top100/blob/main/README.md" target="_blank" rel="noopener noreferrer">查看采集与部署技术文档 ↗</a></p>
+          <p data-site-copy="body">简介和分类依据公开项目资料整理。缺少可用的中文简介时保留项目原文；项目资料发生变化后，旧的人工整理内容可能失效并等待重新核对。</p>
+          <p data-site-copy="body"><a href="https://github.com/dsheval/dsh-top100/blob/main/README.md" target="_blank" rel="noopener noreferrer">查看采集与部署技术文档 ↗</a></p>
         </section>
 
       </article>

--- a/web/public/docs.html
+++ b/web/public/docs.html
@@ -55,40 +55,7 @@
       }
 
       [id] {
-        scroll-margin-top: 88px;
-      }
-
-      .nav-shell {
-        position: sticky;
-        z-index: 20;
-        top: 0;
-        border-bottom: 1px solid rgba(23, 33, 31, 0.13);
-        background: color-mix(in srgb, var(--paper) 94%, transparent);
-        backdrop-filter: blur(12px);
-      }
-
-      .nav {
-        display: flex;
-        width: min(calc(100% - 48px), var(--content));
-        min-height: 62px;
-        margin: 0 auto;
-        align-items: center;
-        justify-content: space-between;
-        gap: 24px;
-      }
-
-      .wordmark,
-      .back-link {
-        text-decoration: none;
-      }
-
-      .wordmark {
-        display: inline-flex;
-        align-items: center;
-        gap: 10px;
-        font-size: 18px;
-        font-weight: 850;
-        letter-spacing: -0.03em;
+        scroll-margin-top: calc(var(--site-header-height) + 16px);
       }
 
       .wordmark-mark {
@@ -240,7 +207,7 @@
       .toc {
         position: sticky;
         z-index: 9;
-        top: 62px;
+        top: var(--site-header-height);
         display: grid;
         margin: 0 0 68px;
         padding: 0;
@@ -530,22 +497,6 @@
         white-space: nowrap;
       }
 
-      .footer {
-        display: flex;
-        min-height: 110px;
-        padding: 28px max(24px, calc((100vw - var(--content)) / 2));
-        align-items: center;
-        justify-content: space-between;
-        gap: 24px;
-        color: var(--paper);
-        background: var(--ink);
-        font-family: var(--mono);
-        font-size: 12px;
-        font-weight: 750;
-        letter-spacing: 0.04em;
-        text-transform: uppercase;
-      }
-
       @media (max-width: 960px) {
         .toc {
           position: static;
@@ -630,15 +581,7 @@
           font-size: 42px;
         }
 
-        .footer {
-          display: block;
-        }
 
-        .footer span:last-child {
-          display: block;
-          margin-top: 8px;
-          color: #b7c3bf;
-        }
       }
 
       @media (prefers-reduced-motion: reduce) {
@@ -654,34 +597,53 @@
           transform: none;
         }
       }
+      @media (min-width: 961px) {
+        .doc-section { scroll-margin-top: calc(var(--site-header-height) + 92px); }
+      }
     </style>
+    <link rel="stylesheet" href="./site-controls.css?v=20260905-nav2" />
+    <link rel="canonical" href="https://dsheval.ai/top100/?page=docs" />
+    <link rel="stylesheet" href="./site-chrome.css?v=20260905-nav2" />
   </head>
   <body>
-    <div class="nav-shell">
-      <nav class="nav" aria-label="文档导航">
-        <a class="wordmark" href="./" aria-label="返回 dsh-top100 首页">
-          <img src="./favicon.svg" alt="" width="30" height="30" />
-          <span>dsh-top100 / Docs</span>
-        </a>
-        <a class="back-link" href="./#ranking">返回榜单</a>
+    <header class="dsh-site-header">
+      <div class="dsh-site-container dsh-header-inner">
+        <a class="dsh-brand-link" href="/" aria-label="DSH-Eval 首页"><span class="dsh-brand" translate="no"><strong>DSH</strong><span aria-hidden="true">/</span><b>EVAL</b></span></a>
+        <nav class="dsh-desktop-nav" aria-label="DSH-Eval 主导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/faq">常见问题</a></nav>
+        <details class="dsh-mobile-menu">
+          <summary>菜单<span class="dsh-menu-icon" aria-hidden="true"></span></summary>
+          <nav aria-label="DSH-Eval 移动端导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/faq">常见问题</a></nav>
+        </details>
+      </div>
+    </header>
+
+    <main>
+      <nav class="top100-section-nav" aria-label="Top100 栏目导航">
+        <a class="top100-section-title" href="./"><img src="./assets/dsh-top100-mark.svg" width="28" height="28" alt="" /><span>dsh-top100</span></a>
+        <div class="nav-links">
+          <a href="./#ranking">插件榜单</a>
+          <a href="./skills.html#ranking">Skills 榜单</a>
+          <a href="./?page=dsh#dsh">安装指南</a>
+          <a href="./?page=docs#docs" aria-current="page">排名方法</a>
+          <a href="https://github.com/dsheval/dsh-top100" target="_blank" rel="noopener noreferrer">GitHub <span aria-hidden="true">↗</span></a>
+        </div>
       </nav>
-    </div>
 
     <header class="docs-hero">
       <div class="docs-hero-inner">
-        <h1>How rankings and plugins work.</h1>
+        <h1>排名方法</h1>
         <p class="docs-title-zh">榜单、分类与 DSH 插件。</p>
       </div>
       <div class="orbit" aria-hidden="true"></div>
     </header>
 
-    <main class="docs-layout">
+    <div class="docs-layout">
       <nav class="toc" aria-label="文档目录">
         <span class="toc-title">本页目录</span>
         <a href="#overview" data-section="01">产品与榜单</a>
         <a href="#plugin" data-section="02">DSH 插件</a>
         <a href="#discovery" data-section="03">仓库发现</a>
-        <a href="#verification" data-section="04">兼容验证</a>
+        <a href="#verification" data-section="04">收录规则</a>
         <a href="#ranking" data-section="05">排行算法</a>
         <a href="#database" data-section="06">数据发布</a>
       </nav>
@@ -691,8 +653,7 @@
           <p class="section-kicker">01 · Overview</p>
           <h2>三个榜单与分类筛选</h2>
           <p class="lead">
-            dsh-top100 是 DeepSeek Harness 公开插件生态的发现、验证和趋势索引。只有已验证的 DSH
-            Plugin 参与排名，排名单位是 GitHub 仓库；Skills 使用独立技能库浏览。
+            dsh-top100 帮助你发现 DSH 插件、比较项目热度并找到安装入口。排名单位是 GitHub 仓库；Skills 单独展示。收录检查确认项目与 DSH 的关联证据，不代表已安装验证、通过能力评测或安全审计。
           </p>
           <div class="card-grid four">
             <article class="doc-card">
@@ -708,39 +669,27 @@
             <article class="doc-card">
               <span class="card-label">All verified</span>
               <h3>总榜</h3>
-              <p>展示全部活跃、已验证仓库，严格按当前 GitHub Stars 总数降序排列。</p>
+              <p>展示全部活跃且符合收录规则的插件仓库，按当前 GitHub Stars 总数降序排列。</p>
             </article>
             <article class="doc-card">
               <span class="card-label">README semantics</span>
               <h3>分类筛选</h3>
-              <p>分类不再是一张榜：它可叠加在综合热度、新锐或 Stars 排序之上；同一 Plugin 可以进入多个分类。</p>
+              <p>在综合热度、新锐或 Stars 排序下，按用途进一步筛选；同一插件可以属于多个分类。</p>
             </article>
           </div>
           <h3>README 智能分类</h3>
           <p>
             DeepSeek 根据 README、描述和 topics 选择一个主分类，再补充一至两个有明确依据的相关分类。
-            分类结果连同置信度、依据和模型信息写入 SQLite，并随榜单 JSON 发布；模型不可用时使用可追踪的规则回退。
+            同一项目可能属于多个分类，所以分类数量相加可能大于项目总数。模型不可用时，使用基于项目资料的规则分类。
           </p>
         </section>
 
         <section class="doc-section" id="plugin">
           <p class="section-kicker">02 · DSH Plugin</p>
           <h2>排行榜也可以直接进入 DSH</h2>
-          <p class="lead">
-            dsh-top100 提供可独立安装的 DSH 插件。用户不需要下载 Collector、SQLite 或网页后端，
-            即可在 DSH 设置页浏览和搜索榜单，并对作者明确提供且验证通过的安装源进行确认安装。
-          </p>
-          <div class="pipeline" aria-label="DSH 插件数据流">
-            <span>rankings.json</span>
-            <span>插件 Host</span>
-            <span>本地 API</span>
-            <span>设置页 Client</span>
-            <span>DSH Profile</span>
-          </div>
-          <p>
-            插件和官方网站共用同一份线上榜单与分类定义；Host 负责远端数据缓存、安装源验证和受控安装，
-            Client 只通过同源本地接口读取数据。安装说明见首页“安装 dsh-top100”。
-          </p>
+          <p class="lead">安装 dsh-top100 后，可以在 DSH 设置页浏览、搜索榜单，并复制或确认运行项目提供的安装命令。</p>
+          <p>插件与网站共用线上榜单。安装来源可以解析，不代表已经实际安装验证；运行前仍需核对项目说明、宿主版本和所需权限。</p>
+          <p><a href="./?page=dsh#dsh">查看安装指南 →</a></p>
           <p>
             安装包还内置 <code>recommend-dsh-plugins</code> Skill，并注册只读的
             <code>dsh_top100_search</code> 搜索工具。当用户在 DSH 对话中询问“该装哪个插件”或描述所需能力时，
@@ -752,7 +701,7 @@
           <p class="section-kicker">03 · Discovery</p>
           <h2>如何尽可能完整地发现仓库</h2>
           <p class="lead">
-            GitHub 没有 DSH 官方全局插件注册表，因此系统采用多来源召回，再使用同一验证器过滤噪声。
+            系统从多个公开来源发现候选项目，再按同一套收录规则筛选。自动发现可能有遗漏，收录范围以当日快照为准。
           </p>
           <div class="pipeline" aria-label="数据处理流程">
             <span>多来源候选</span>
@@ -774,8 +723,7 @@
           <p class="section-kicker">04 · Verification</p>
           <h2>什么仓库可以入榜</h2>
           <p class="lead">
-            Topic 和关键词只负责召回，不直接证明兼容性。候选仓库必须提供可验证的 DSH
-            插件、Skill、Bundle 或 Cordis 集成证据。
+            名称、标签和关键词用于发现候选项目，不能单独证明兼容性。候选仓库还需提供 DSH 插件、Skill、Bundle 或 Cordis 集成等结构证据；这些检查不等同于实际运行测试。
           </p>
           <div class="table-wrap">
             <table>
@@ -847,44 +795,29 @@
 
         <section class="doc-section" id="database">
           <p class="section-kicker">06 · Persistence</p>
-          <h2>数据库、每日更新与企业部署</h2>
-          <p class="lead">
-            当前使用 SQLite 作为单服务器事实来源。它保存最新仓库状态、每日 Stars、中文简介来源和采集审计，
-            前端不会直接连接数据库。
-          </p>
-          <div class="table-wrap">
-            <table>
-              <thead>
-                <tr><th>表</th><th>用途</th></tr>
-              </thead>
-              <tbody>
-                <tr><td><code>repositories</code></td><td>仓库最新状态、Stars、许可证、来源和活跃状态</td></tr>
-                <tr><td><code>repository_daily_stats</code></td><td>按仓库和日期保存 Stars、Forks 与 Issues 快照</td></tr>
-                <tr><td><code>repository_summaries</code></td><td>中文简介、源内容哈希、模型与提示版本</td></tr>
-                <tr><td><code>repository_categories</code></td><td>多标签分类、置信度、README 依据、模型和分类时间</td></tr>
-                <tr><td><code>collection_runs</code></td><td>每次采集的开始、结束、状态、数量与错误信息</td></tr>
-              </tbody>
-            </table>
-          </div>
-          <h3>更新节奏</h3>
-          <p>
-            北京时间每天 06:00 运行增量发现并刷新全部已收录仓库；每周日运行完整分片发现。
-            成功采集后在一个事务中导入 SQLite，再生成公开 JSON。
-          </p>
-          <h3>迁移与企业扩展</h3>
-          <p>
-            迁移服务器时复制完整 <code>runtime/</code> 即可保留数据库、Stars 历史和简介缓存。
-            单机单写场景继续使用 SQLite 更简单；当出现多实例写入、权限隔离、审计查询或高并发 API
-            需求时，再升级为 PostgreSQL，并保留同一公开 JSON 输出层。
-          </p>
+          <h2>数据何时更新</h2>
+          <p class="lead">计划在北京时间每天 06:00 开始更新，每周日进行更完整的仓库发现。采集需要时间，页面上显示的快照时间才是本次数据的实际更新时间。</p>
+          <h3>为什么数据可能暂时没有变化</h3>
+          <p>GitHub 请求限制、网络异常或采集失败可能延迟更新。新快照生成成功后才发布；更新未完成时继续提供上次有效数据。</p>
+          <h3>简介与分类如何更新</h3>
+          <p>简介和分类依据公开项目资料整理。缺少可用的中文简介时保留项目原文；项目资料发生变化后，旧的人工整理内容可能失效并等待重新核对。</p>
+          <p><a href="https://github.com/dsheval/dsh-top100/blob/main/README.md" target="_blank" rel="noopener noreferrer">查看采集与部署技术文档 ↗</a></p>
         </section>
 
       </article>
+    </div>
     </main>
 
-    <footer class="footer">
-      <span>dsh-top100 · Documentation</span>
-      <span>Discover · Verify · Snapshot · Rank · Publish</span>
+    <footer class="dsh-site-footer">
+      <div class="dsh-site-container dsh-footer-inner">
+        <div class="dsh-footer-intro"><a class="dsh-brand-link" href="/" aria-label="DSH-Eval 首页"><span class="dsh-brand" translate="no"><strong>DSH</strong><span aria-hidden="true">/</span><b>EVAL</b></span></a><p>公开评测，发现值得关注的项目。</p></div>
+        <nav class="dsh-footer-links" aria-label="页脚导航">
+          <a href="https://github.com/dsheval/dsh-eval" target="_blank" rel="noopener noreferrer">评测源码 <span aria-hidden="true">↗</span><span class="dsh-visually-hidden">（新窗口打开）</span></a>
+          <a href="https://github.com/dsheval/dsh-top100" target="_blank" rel="noopener noreferrer">Top100 源码 <span aria-hidden="true">↗</span><span class="dsh-visually-hidden">（新窗口打开）</span></a>
+          <a href="/faq">常见问题</a>
+        </nav>
+        <span class="dsh-copyright">© 2026 DSH-Eval</span>
+      </div>
     </footer>
   </body>
 </html>

--- a/web/public/dsh.html
+++ b/web/public/dsh.html
@@ -1,8 +1,8 @@
 <div class="docs-layout dsh-guide">
   <article class="docs-content">
     <div class="dsh-prerequisites">
-      <p class="dsh-requirements">开始前确认：<strong>DSH Web 0.1.0-rc.6+</strong> · <strong>Node.js 22.13+</strong></p>
-      <p class="dsh-scope-note">以下只安装 dsh-top100，不会自动安装榜单中的项目。</p>
+      <p class="dsh-requirements" data-site-copy="body">开始前确认：<strong>DSH Web 0.1.0-rc.6+</strong> · <strong>Node.js 22.13+</strong></p>
+      <p class="dsh-scope-note" data-site-copy="note">以下只安装 dsh-top100，不会自动安装榜单中的项目。</p>
     </div>
 
     <section class="doc-section" id="install" aria-label="安装步骤">
@@ -11,19 +11,19 @@
           <span class="dsh-step-number" aria-hidden="true">1</span>
           <div class="dsh-step-content">
             <h2>安装榜单插件</h2>
-            <p>打开终端或 PowerShell，在 DSH 源码目录外运行：</p>
+            <p data-site-copy="body">打开终端或 PowerShell，在 DSH 源码目录外运行：</p>
             <div class="dsh-command-row">
               <code class="dsh-install-command">npx @deepseek-ai/dsh plugin --profile web add @dsheval/dsh-top100-plugin@1.3.1</code>
               <button class="dsh-copy-button" type="button" data-copy-command="npx @deepseek-ai/dsh plugin --profile web add @dsheval/dsh-top100-plugin@1.3.1" aria-label="复制插件安装命令">复制</button>
             </div>
-            <p>命令固定安装当前版本。</p>
+            <p data-site-copy="note">命令固定安装当前版本。</p>
           </div>
         </li>
         <li class="dsh-install-step">
           <span class="dsh-step-number" aria-hidden="true">2</span>
           <div class="dsh-step-content">
             <h2>启动 DSH Web</h2>
-            <p>安装完成后，在同一个终端运行：</p>
+            <p data-site-copy="body">安装完成后，在同一个终端运行：</p>
             <div class="dsh-command-row">
               <code class="dsh-install-command">npx @deepseek-ai/dsh web</code>
               <button class="dsh-copy-button" type="button" data-copy-command="npx @deepseek-ai/dsh web" aria-label="复制 DSH 启动命令">复制</button>
@@ -34,11 +34,11 @@
           <span class="dsh-step-number" aria-hidden="true">3</span>
           <div class="dsh-step-content">
             <h2>进入插件排行</h2>
-            <p>在 DSH Web 中依次打开：</p>
+            <p data-site-copy="body">在 DSH Web 中依次打开：</p>
             <div class="dsh-open-target" aria-label="设置，然后打开插件排行">
               <span>设置</span><span aria-hidden="true">→</span><strong>插件排行</strong>
             </div>
-            <p class="dsh-success">看到榜单后，在「已安装」中核对版本为 <span data-install-version>1.3.1</span>；若 DSH 已在运行，请先重启。</p>
+            <p class="dsh-success" data-site-copy="body">看到榜单后，在「已安装」中核对版本为 <span data-install-version>1.3.1</span>；若 DSH 已在运行，请先重启。</p>
           </div>
         </li>
       </ol>
@@ -46,23 +46,23 @@
 
     <section class="doc-section" id="preview" aria-labelledby="preview-title">
       <h2 id="preview-title">安装后的界面</h2>
-      <p class="dsh-section-intro">在插件市场搜索、筛选和浏览榜单。</p>
+      <p class="dsh-section-intro" data-site-copy="body">在插件市场搜索、筛选和浏览榜单。</p>
       <figure class="dsh-preview-item dsh-market-preview">
         <a class="dsh-preview-link" href="./assets/dsh-plugin-market.png" target="_blank" rel="noopener noreferrer" aria-label="查看插件市场大图（新标签页）">
           <img src="./assets/dsh-plugin-market.png" width="1600" height="1600" loading="lazy" decoding="async" alt="DSH 设置中的插件排行页面，包含插件与 Skills 切换、搜索、分类和榜单。">
         </a>
-        <figcaption>本地开发版截图 · 点击查看大图</figcaption>
+        <figcaption data-site-copy="note">本地开发版截图 · 点击查看大图</figcaption>
       </figure>
       <details class="dsh-detail dsh-install-example">
         <summary>如何安装榜单中的其他插件？</summary>
         <div class="dsh-detail-body">
-          <p>点击项目的「安装」，核对版本、来源与脚本后再确认。安装后重启 DSH，并检查插件是否正常运行。</p>
-          <p>没有「安装」按钮？点击「查看项目」，到项目仓库了解安装方式。<strong>来源校验不等于安全审核。</strong></p>
+          <p data-site-copy="body">点击项目的「安装」，核对版本、来源与脚本后再确认。安装后重启 DSH，并检查插件是否正常运行。</p>
+          <p data-site-copy="body">没有「安装」按钮？点击「查看项目」，到项目仓库了解安装方式。<strong>来源校验不等于安全审核。</strong></p>
           <figure class="dsh-preview-item dsh-confirm-preview">
             <a class="dsh-preview-link" href="./assets/dsh-install-confirm.png" target="_blank" rel="noopener noreferrer" aria-label="查看安装确认大图（新标签页）">
               <img src="./assets/dsh-install-confirm.png" width="960" height="802" loading="lazy" decoding="async" alt="以 dsh-pet 为例的安装确认窗口，展示精确版本、安装脚本、重启提醒及风险同意选项。">
             </a>
-            <figcaption>安装确认示例：dsh-pet · 点击查看大图</figcaption>
+            <figcaption data-site-copy="note">安装确认示例：dsh-pet · 点击查看大图</figcaption>
           </figure>
         </div>
       </details>
@@ -73,10 +73,10 @@
       <details class="dsh-detail" id="other-methods">
         <summary>使用全局 dsh 或源码安装</summary>
         <div class="dsh-detail-body">
-          <p>已在使用下面的方式？请沿用原来的方式安装。<strong>安装和启动必须使用相同的命令前缀，不要混用。</strong></p>
+          <p data-site-copy="body">已在使用下面的方式？请沿用原来的方式安装。<strong>安装和启动必须使用相同的命令前缀，不要混用。</strong></p>
           <section class="dsh-method" aria-labelledby="global-method-title">
             <h3 id="global-method-title">已安装全局 dsh 命令</h3>
-            <p>确认 <code>dsh --version</code> 能正常返回，再依次安装、启动：</p>
+            <p data-site-copy="body">确认 <code>dsh --version</code> 能正常返回，再依次安装、启动：</p>
             <div class="dsh-command-group">
               <div class="dsh-command-row">
                 <code class="dsh-install-command">dsh plugin --profile web add @dsheval/dsh-top100-plugin@1.3.1</code>
@@ -90,7 +90,7 @@
           </section>
           <section class="dsh-method" aria-labelledby="source-method-title">
             <h3 id="source-method-title">从 DSH 源码运行</h3>
-            <p>进入 DSH 源码仓库根目录，再依次安装、启动：</p>
+            <p data-site-copy="body">进入 DSH 源码仓库根目录，再依次安装、启动：</p>
             <div class="dsh-command-group">
               <div class="dsh-command-row">
                 <code class="dsh-install-command">pnpm dsh plugin --profile web add @dsheval/dsh-top100-plugin@1.3.1</code>
@@ -108,25 +108,25 @@
         <summary>安装后找不到「插件排行」</summary>
         <div class="dsh-detail-body">
           <ul class="dsh-help-list">
-            <li>确认 DSH Web 版本为 0.1.0-rc.6 或更新版本。</li>
-            <li>确认安装和启动用了相同的命令前缀，且使用 <code>web</code> profile。</li>
-            <li>如果安装时 DSH 已在运行，用原来的方式重启，再刷新浏览器。</li>
+            <li data-site-copy="body">确认 DSH Web 版本为 0.1.0-rc.6 或更新版本。</li>
+            <li data-site-copy="body">确认安装和启动用了相同的命令前缀，且使用 <code>web</code> profile。</li>
+            <li data-site-copy="body">如果安装时 DSH 已在运行，用原来的方式重启，再刷新浏览器。</li>
           </ul>
         </div>
       </details>
       <details class="dsh-detail">
         <summary>npx 长时间没有输出</summary>
         <div class="dsh-detail-body">
-          <p>先运行 <code>npx @deepseek-ai/dsh --version</code>。如果也一直没有输出，可能卡在依赖解析；停止命令，改用上面的源码方式。</p>
-          <p>不要单独添加 <code>--legacy-peer-deps</code>，以免漏装运行时依赖。详见 <a href="https://github.com/deepseek-ai/deepseek-harness/discussions/3786" target="_blank" rel="noopener noreferrer">DSH 上游讨论</a>。</p>
+          <p data-site-copy="body">先运行 <code>npx @deepseek-ai/dsh --version</code>。如果也一直没有输出，可能卡在依赖解析；停止命令，改用上面的源码方式。</p>
+          <p data-site-copy="body">不要单独添加 <code>--legacy-peer-deps</code>，以免漏装运行时依赖。详见 <a href="https://github.com/deepseek-ai/deepseek-harness/discussions/3786" target="_blank" rel="noopener noreferrer">DSH 上游讨论</a>。</p>
         </div>
       </details>
       <details class="dsh-detail" id="features">
         <summary>版本与数据来源</summary>
         <div class="dsh-detail-body">
-          <p>当前发布版本为 <a href="https://www.npmjs.com/package/@dsheval/dsh-top100-plugin/v/1.3.1" target="_blank" rel="noopener noreferrer">v1.3.1</a>。上面的命令固定安装此版本，不会自动选择旧版。</p>
-          <p>数据来自 DSHeval 排行服务。网站与插件使用同一份榜单数据，每日更新。</p>
-          <p>安装包包含排行插件和 <code>recommend-dsh-plugins</code> Skill，不包含采集程序、数据库或网站后端。</p>
+          <p data-site-copy="body">当前发布版本为 <a href="https://www.npmjs.com/package/@dsheval/dsh-top100-plugin/v/1.3.1" target="_blank" rel="noopener noreferrer">v1.3.1</a>。上面的命令固定安装此版本，不会自动选择旧版。</p>
+          <p data-site-copy="body">数据来自 DSHeval 排行服务。网站与插件使用同一份榜单数据，每日更新。</p>
+          <p data-site-copy="body">安装包包含排行插件和 <code>recommend-dsh-plugins</code> Skill，不包含采集程序、数据库或网站后端。</p>
         </div>
       </details>
     </section>

--- a/web/public/dsheval.html
+++ b/web/public/dsheval.html
@@ -1,10 +1,10 @@
-<main class="docs-layout">
+<div class="docs-layout">
   <article class="docs-content">
     <section class="doc-section" id="overview">
-      <p class="section-kicker">DSH-Eval</p>
+      <p class="section-kicker" data-site-label="section" lang="en">DSH-Eval</p>
       <h2>公开评测与任务证据</h2>
-      <p class="lead">DSH-Eval 面向 DSH Agent 与插件，公开真实任务中的表现、评测方法与证据。Top100 是其中的插件与 Skills 发现栏目，收录不代表已通过能力评测。</p>
-      <p><a href="/">访问 DSH-Eval 首页</a> · <a href="/results">查看评测结果</a> · <a href="/methodology">了解评测方法</a></p>
+      <p class="lead" data-site-copy="body">DSH-Eval 面向 DSH Agent 与插件，公开真实任务中的表现、评测方法与证据。Top100 是其中的插件与 Skills 发现栏目，收录不代表已通过能力评测。</p>
+      <p data-site-copy="body"><a href="/">访问 DSH-Eval 首页</a> · <a href="/results">查看评测结果</a> · <a href="/methodology">了解评测方法</a></p>
     </section>
   </article>
-</main>
+</div>

--- a/web/public/dsheval.html
+++ b/web/public/dsheval.html
@@ -1,15 +1,10 @@
 <main class="docs-layout">
   <article class="docs-content">
     <section class="doc-section" id="overview">
-      <p class="section-kicker">DSHeval · Coming next</p>
-      <h2>DSHeval 即将上线</h2>
-      <p class="lead">
-        面向 DeepSeek Harness 生态的评测页面正在准备中。后续将在这里展示完整的评测内容、
-        方法和结果，帮助用户更直观地理解项目能力。
-      </p>
-      <div class="callout">
-        <strong>Coming soon：</strong>更多 DSHeval 内容将在页面完善后正式开放。
-      </div>
+      <p class="section-kicker">DSH-Eval</p>
+      <h2>公开评测与任务证据</h2>
+      <p class="lead">DSH-Eval 面向 DSH Agent 与插件，公开真实任务中的表现、评测方法与证据。Top100 是其中的插件与 Skills 发现栏目，收录不代表已通过能力评测。</p>
+      <p><a href="/">访问 DSH-Eval 首页</a> · <a href="/results">查看评测结果</a> · <a href="/methodology">了解评测方法</a></p>
     </section>
   </article>
 </main>

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -5,35 +5,35 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
-      content="dsh-top100 是可信的 DSH 插件发现与排行市场，通过热度、增长、活跃度和安装证据，帮助你找到值得安装的插件。"
+      content="dsh-top100 是 DSH-Eval 旗下的插件与 Skills 发现栏目，通过热度、增长、活跃度和安装证据，帮助你找到值得安装的插件。"
     />
     <meta name="theme-color" content="#d9e7e2" />
-    <link rel="canonical" href="https://www.dsheval.ai/" />
-    <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+    <link rel="canonical" href="https://dsheval.ai/top100/" />
+    <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="zh_CN" />
-    <meta property="og:site_name" content="dsh-top100" />
+    <meta property="og:site_name" content="DSH-Eval" />
     <meta property="og:title" content="dsh-top100 · 发现值得安装的 DSH 插件" />
-    <meta property="og:description" content="可信的 DSH 插件发现与排行市场。按热度、增长、项目质量和安装证据持续更新。" />
-    <meta property="og:url" content="https://www.dsheval.ai/" />
-    <meta property="og:image" content="https://www.dsheval.ai/assets/dsh-top100-og.png" />
+    <meta property="og:description" content="DSH-Eval 旗下的插件与 Skills 发现栏目。按热度、增长、项目质量和安装证据持续更新。" />
+    <meta property="og:url" content="https://dsheval.ai/top100/" />
+    <meta property="og:image" content="https://dsheval.ai/top100/assets/dsh-top100-og.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="dsh-top100 · 发现值得安装的 DSH 插件" />
-    <meta name="twitter:description" content="可信的 DSH 插件发现与排行市场。" />
-    <meta name="twitter:image" content="https://www.dsheval.ai/assets/dsh-top100-og.png" />
+    <meta name="twitter:description" content="DSH-Eval 旗下的插件与 Skills 发现栏目。" />
+    <meta name="twitter:image" content="https://dsheval.ai/top100/assets/dsh-top100-og.png" />
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "CollectionPage",
         "name": "dsh-top100",
-        "url": "https://www.dsheval.ai/",
-        "description": "可信的 DSH 插件发现与排行市场",
+        "url": "https://dsheval.ai/top100/",
+        "description": "DSH-Eval 旗下的插件与 Skills 发现栏目",
         "isPartOf": {
           "@type": "WebSite",
-          "name": "DSHeval",
-          "url": "https://www.dsheval.ai/"
+          "name": "DSH-Eval",
+          "url": "https://dsheval.ai/"
         },
         "about": {
           "@type": "SoftwareApplication",
@@ -101,46 +101,8 @@
         color: inherit;
       }
 
-      .nav-shell {
-        position: sticky;
-        z-index: 20;
-        top: 0;
-        border-bottom: 1px solid rgba(23, 33, 31, 0.12);
-        background: color-mix(in srgb, var(--paper) 94%, transparent);
-        backdrop-filter: blur(12px);
-      }
 
-      .nav {
-        display: flex;
-        width: min(calc(100% - 48px), var(--content));
-        min-height: 62px;
-        margin: 0 auto;
-        align-items: center;
-        justify-content: space-between;
-        gap: 32px;
-      }
 
-      .wordmark {
-        display: inline-flex;
-        align-items: center;
-        gap: 10px;
-        font-size: 18px;
-        font-weight: 800;
-        letter-spacing: -0.03em;
-        text-decoration: none;
-      }
-
-      .wordmark-logo {
-        display: block;
-        width: 30px;
-        height: 30px;
-        flex: 0 0 30px;
-        border: 1px solid rgba(23, 33, 31, 0.14);
-        border-radius: 50%;
-        background: var(--card);
-        object-fit: cover;
-        object-position: center;
-      }
 
       .nav-label {
         margin: 0;
@@ -1420,7 +1382,7 @@
       .inline-docs .toc {
         position: sticky;
         z-index: 9;
-        top: 62px;
+        top: var(--site-header-height);
         display: grid;
         margin: 0 0 68px;
         padding: 0;
@@ -1475,7 +1437,7 @@
 
       .inline-docs .doc-section {
         padding: 0 0 72px;
-        scroll-margin-top: 90px;
+        scroll-margin-top: calc(var(--site-header-height) + 28px);
         border-bottom: 1px solid var(--line);
       }
 
@@ -1684,7 +1646,7 @@
 
       body:has(#dsh-view:not([hidden])) .ranking {
         background: var(--paper);
-        scroll-margin-top: 64px;
+        scroll-margin-top: var(--site-header-height);
       }
 
       body:has(#dsh-view:not([hidden])) .ranking-inner {
@@ -2078,33 +2040,12 @@
         outline-offset: 3px;
       }
 
-      .footer {
-        display: flex;
-        min-height: 96px;
-        padding: 24px max(24px, calc((100vw - var(--content)) / 2));
-        align-items: center;
-        justify-content: space-between;
-        gap: 30px;
-        border-top: 1px solid #6f837c;
-        background: #2b443d;
-        color: var(--paper);
-        font-family: var(--mono);
-        font-size: 12px;
-        font-weight: 700;
-        line-height: 1.6;
-        letter-spacing: 0.05em;
-        text-transform: uppercase;
-      }
-
-      .footer span:last-child {
-        color: #c9d6d1;
-      }
 
       @media (min-width: 721px) {
         .list-head:not([hidden]) {
           position: sticky;
           z-index: 8;
-          top: 62px;
+          top: var(--site-header-height);
           box-shadow: 0 8px 18px rgba(23, 33, 31, 0.08);
         }
       }
@@ -2400,14 +2341,7 @@
           border-left: 0;
         }
 
-        .footer {
-          display: block;
-        }
 
-        .footer span:last-child {
-          display: block;
-          margin-top: 10px;
-        }
       }
 
       /* Homepage market redesign: one data-led signature, restrained elsewhere. */
@@ -2781,10 +2715,6 @@
       }
 
       @media (max-width: 720px) {
-        .nav {
-          width: min(calc(100% - 28px), var(--content));
-          gap: 14px;
-        }
 
         .nav-links {
           gap: 13px;
@@ -2889,40 +2819,40 @@
     <link rel="stylesheet" href="./category-system.css" />
     <link rel="stylesheet" href="./ranking-method.css" />
     <link rel="stylesheet" href="./ranking-rows.css" />
-    <link rel="stylesheet" href="./site-controls.css" />
+    <link rel="stylesheet" href="./site-controls.css?v=20260905-nav2" />
+    <link rel="stylesheet" href="./site-chrome.css?v=20260905-nav2" />
   </head>
   <body>
-    <div class="nav-shell">
-      <nav class="nav" aria-label="主导航">
-        <a class="wordmark" href="./#top" aria-label="dsh-top100 首页">
-          <img
-            class="wordmark-logo"
-            src="./favicon.svg"
-            alt=""
-            width="30"
-            height="30"
-          />
-          <span>dsh-top100</span>
-        </a>
+    <header class="dsh-site-header">
+      <div class="dsh-site-container dsh-header-inner">
+        <a class="dsh-brand-link" href="/" aria-label="DSH-Eval 首页"><span class="dsh-brand" translate="no"><strong>DSH</strong><span aria-hidden="true">/</span><b>EVAL</b></span></a>
+        <nav class="dsh-desktop-nav" aria-label="DSH-Eval 主导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/faq">常见问题</a></nav>
+        <details class="dsh-mobile-menu">
+          <summary>菜单<span class="dsh-menu-icon" aria-hidden="true"></span></summary>
+          <nav aria-label="DSH-Eval 移动端导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/faq">常见问题</a></nav>
+        </details>
+      </div>
+    </header>
+
+    <main id="top">
+      <nav class="top100-section-nav" aria-label="Top100 栏目导航">
+        <a class="top100-section-title" href="./"><img src="./assets/dsh-top100-mark.svg" width="28" height="28" alt="" /><span>dsh-top100</span></a>
         <div class="nav-links">
           <a href="#ranking" data-content-switch="ranking">插件榜单</a>
           <a href="./skills.html#ranking">Skills 榜单</a>
           <a href="?page=dsh#dsh" data-content-switch="dsh">安装指南</a>
           <a href="?page=docs#docs" data-content-switch="docs">排名方法</a>
-          <a href="https://github.com/dsheval/dsh-top100" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a href="https://github.com/dsheval/dsh-top100" target="_blank" rel="noopener noreferrer">GitHub <span aria-hidden="true">↗</span></a>
         </div>
       </nav>
-    </div>
-
-    <main id="top">
       <section class="hero">
         <div class="hero-inner">
           <div class="hero-copy">
-            <p class="eyebrow">Verified DSH plugin market · Daily snapshot</p>
+            <p class="eyebrow">DSH-Eval · Plugin discovery · Daily snapshot</p>
             <h1><span>发现值得安装的</span><span>DSH 插件。</span></h1>
             <p class="hero-description">
               用增长、活跃度、项目质量和安装证据筛选插件，
-              从具体需求出发，而不只是追逐 Stars。
+              从具体需求出发，而不只是追逐 Stars。收录不代表已通过能力评测。
             </p>
             <form class="hero-search" id="hero-search-form" role="search">
               <label class="sr-only" for="hero-search">搜索全部 DSH 插件</label>
@@ -2989,6 +2919,7 @@
               <p class="section-kicker">Discover · Compare · Install</p>
               <h2>用证据比较，<br />不只看 Stars。</h2>
               <p class="ranking-explainer">Top 100 是增长、活跃度、数据质量与总体关注度的综合热度榜；总榜才按 GitHub Stars 排序。</p>
+              <p class="ranking-source-note">数据来自公开项目信息与 GitHub 指标。优先展示整理后的中文简介，缺少时保留项目原文。</p>
             </div>
             <div class="ranking-meta" aria-live="polite">
               <p id="ranking-meta-title">DEEPSEEK HARNESS PLUGINS · TOP 100</p>
@@ -3094,7 +3025,7 @@
           <div class="list-head" id="list-head" aria-hidden="true">
             <span id="rank-head">排名</span>
             <span>插件</span>
-            <span>中文简介</span>
+            <span>项目简介</span>
             <span class="signal-head">更新与增长</span>
             <span id="metric-head">GitHub Stars</span>
           </div>
@@ -3156,9 +3087,16 @@
       </section>
     </main>
 
-    <footer class="footer">
-      <span>dsh-top100 · DSH plugin leaderboard</span>
-      <span>Verified sources · AI Chinese summaries · GitHub stars</span>
+    <footer class="dsh-site-footer">
+      <div class="dsh-site-container dsh-footer-inner">
+        <div class="dsh-footer-intro"><a class="dsh-brand-link" href="/" aria-label="DSH-Eval 首页"><span class="dsh-brand" translate="no"><strong>DSH</strong><span aria-hidden="true">/</span><b>EVAL</b></span></a><p>公开评测，发现值得关注的项目。</p></div>
+        <nav class="dsh-footer-links" aria-label="页脚导航">
+          <a href="https://github.com/dsheval/dsh-eval" target="_blank" rel="noopener noreferrer">评测源码 <span aria-hidden="true">↗</span><span class="dsh-visually-hidden">（新窗口打开）</span></a>
+          <a href="https://github.com/dsheval/dsh-top100" target="_blank" rel="noopener noreferrer">Top100 源码 <span aria-hidden="true">↗</span><span class="dsh-visually-hidden">（新窗口打开）</span></a>
+          <a href="/faq">常见问题</a>
+        </nav>
+        <span class="dsh-copyright">© 2026 DSH-Eval</span>
+      </div>
     </footer>
 
     <template id="plugin-template">
@@ -3208,13 +3146,13 @@
         describedBy: "category-hover-description",
       });
 
-      const MANIFEST_URL = "./data/manifest.json";
+      const MANIFEST_URL = "/data/manifest.json";
       const LEGACY_URLS = Object.freeze({
-        hot: "./data/rankings-hot.json",
-        rising: "./data/rankings-rising.json",
-        total: "./data/rankings-total.json",
-        skills: "./data/rankings-skills.json",
-        search: "./data/rankings-search.json",
+        hot: "/data/rankings-hot.json",
+        rising: "/data/rankings-rising.json",
+        total: "/data/rankings-total.json",
+        skills: "/data/rankings-skills.json",
+        search: "/data/rankings-search.json",
       });
 
       const list = document.querySelector("#plugin-list");
@@ -3716,10 +3654,15 @@
             `${categoryLabels[category] ?? "全部分类"}，${formatStars(count)} 个插件`
           );
         }
+        if (!categoryDescription.hidden) {
+          const describedButton = categoryButtons.find((button) => button.dataset.category === categoryDescription.dataset.category);
+          if (describedButton) showCategoryDescription(describedButton);
+        }
       }
 
       function showCategoryDescription(button) {
         const category = button.dataset.category;
+        categoryDescription.dataset.category = category;
         const count = button.querySelector("[data-category-count]").textContent;
         categoryDescriptionTitle.textContent = `${categoryLabels[category] ?? "全部分类"} · ${count} 个插件`;
         categoryDescriptionBody.textContent = categoryDescriptions[category];

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -13,14 +13,14 @@
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="zh_CN" />
     <meta property="og:site_name" content="DSH-Eval" />
-    <meta property="og:title" content="dsh-top100 · 发现值得安装的 DSH 插件" />
+    <meta property="og:title" content="插件榜单 · Top100 · DSH-Eval" />
     <meta property="og:description" content="DSH-Eval 旗下的插件与 Skills 发现栏目。按热度、增长、项目质量和安装证据持续更新。" />
     <meta property="og:url" content="https://dsheval.ai/top100/" />
     <meta property="og:image" content="https://dsheval.ai/top100/assets/dsh-top100-og.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="dsh-top100 · 发现值得安装的 DSH 插件" />
+    <meta name="twitter:title" content="插件榜单 · Top100 · DSH-Eval" />
     <meta name="twitter:description" content="DSH-Eval 旗下的插件与 Skills 发现栏目。" />
     <meta name="twitter:image" content="https://dsheval.ai/top100/assets/dsh-top100-og.png" />
     <script type="application/ld+json">
@@ -46,7 +46,7 @@
         }
       }
     </script>
-    <title>dsh-top100 · 发现值得安装的 DSH 插件</title>
+    <title>插件榜单 · Top100 · DSH-Eval</title>
     <link rel="stylesheet" href="./install-console.css" />
     <style>
       :root {
@@ -1644,6 +1644,10 @@
         display: none;
       }
 
+      body:has(#dsheval-view:not([hidden])) .hero {
+        display: none;
+      }
+
       body:has(#dsh-view:not([hidden])) .ranking {
         background: var(--paper);
         scroll-margin-top: var(--site-header-height);
@@ -2815,12 +2819,57 @@
           display: none;
         }
       }
+      /* Preserve Top100's original hierarchy inside the shared site chrome. */
+      #top #ranking .view-tab {
+        min-height: 54px;
+        padding: 0 20px;
+        font-family: var(--mono);
+        font-size: 15px;
+        font-weight: 800;
+        letter-spacing: 0.025em;
+        text-transform: uppercase;
+      }
+      #top #ranking .view-tab[aria-selected="false"] { color: var(--ink); }
+      #top #ranking .skill-filter { font: 700 14px/1.4 var(--sans); }
+      #top #ranking .category-option {
+        min-height: 50px;
+        padding-inline: 12px;
+        font: 800 13px/20px var(--sans);
+      }
+      #top #ranking .category-option[aria-pressed="true"] {
+        color: var(--ink);
+        background: var(--section-strong);
+        box-shadow: inset 0 -3px 0 var(--accent);
+      }
+      #top #ranking .install-filter { font: 600 14px/20px var(--sans); }
+      #top #ranking .search-input {
+        font: 500 14px/1.4 var(--sans);
+        letter-spacing: 0.01em;
+        border-color: transparent;
+      }
+      #top #ranking .search-input::placeholder { font-weight: 500; }
+      #top #ranking .search-input:focus {
+        border-color: transparent;
+        outline: none;
+        box-shadow: none;
+      }
+      @media (min-width: 641px) and (max-width: 1100px) {
+        #top #ranking .category-option { padding-inline: 10px; }
+      }
+      @media (max-width: 720px) {
+        #top #ranking .view-tab { padding-inline: 8px; font-size: 12px; }
+      }
+      @media (max-width: 640px) {
+        #top #ranking .category-option { min-height: 48px; padding-inline: 11px; font-size: 12px; }
+        #top #ranking .install-filter { font-size: 12px; }
+        #top #ranking .search-input { font-size: 16px; }
+      }
     </style>
     <link rel="stylesheet" href="./category-system.css" />
     <link rel="stylesheet" href="./ranking-method.css" />
     <link rel="stylesheet" href="./ranking-rows.css" />
     <link rel="stylesheet" href="./site-controls.css?v=20260905-nav2" />
-    <link rel="stylesheet" href="./site-chrome.css?v=20260905-nav2" />
+    <link rel="stylesheet" href="./site-chrome.css?v=20260905-type8c" />
   </head>
   <body>
     <header class="dsh-site-header">
@@ -2848,9 +2897,9 @@
       <section class="hero">
         <div class="hero-inner">
           <div class="hero-copy">
-            <p class="eyebrow">DSH-Eval · Plugin discovery · Daily snapshot</p>
-            <h1><span>发现值得安装的</span><span>DSH 插件。</span></h1>
-            <p class="hero-description">
+            <p class="eyebrow dsh-home-eyebrow" data-site-label="page" lang="en">DSH-Eval · <span>Plugin discovery</span> · <span>Daily snapshot</span></p>
+            <h1 class="dsh-home-title"><span>发现值得安装的</span><span>DSH 插件</span></h1>
+            <p class="hero-description dsh-home-description" data-site-copy="lead">
               用增长、活跃度、项目质量和安装证据筛选插件，
               从具体需求出发，而不只是追逐 Stars。收录不代表已通过能力评测。
             </p>
@@ -2905,7 +2954,7 @@
                   data-analytics="install-command"
                 >复制</button>
               </div>
-              <p class="install-console-note">命令固定安装当前版排行插件。使用方法请查看<a href="?page=dsh#dsh" data-content-switch="dsh">安装指南</a>。</p>
+              <p class="install-console-note" data-site-copy="note">命令固定安装当前版排行插件。使用方法请查看<a href="?page=dsh#dsh" data-content-switch="dsh">安装指南</a>。</p>
             </aside>
           </div>
         </div>
@@ -2916,10 +2965,9 @@
           <div class="content-view" id="leaderboard-view">
           <header class="section-header">
             <div>
-              <p class="section-kicker">Discover · Compare · Install</p>
-              <h2>用证据比较，<br />不只看 Stars。</h2>
-              <p class="ranking-explainer">Top 100 是增长、活跃度、数据质量与总体关注度的综合热度榜；总榜才按 GitHub Stars 排序。</p>
-              <p class="ranking-source-note">数据来自公开项目信息与 GitHub 指标。优先展示整理后的中文简介，缺少时保留项目原文。</p>
+              <p class="section-kicker" data-site-label="section" lang="en">Discover · Compare · Install</p>
+              <h2>用证据比较，<br />不只看 Stars</h2>
+              <p class="ranking-explainer" data-site-copy="body">Top 100 是增长、活跃度、数据质量与总体关注度的综合热度榜；总榜才按 GitHub Stars 排序。</p>
             </div>
             <div class="ranking-meta" aria-live="polite">
               <p id="ranking-meta-title">DEEPSEEK HARNESS PLUGINS · TOP 100</p>
@@ -3012,7 +3060,7 @@
                 </button>
               </div>
               <div class="search-status-row">
-                <p class="search-result" id="ranking-search-result">等待插件数据</p>
+                <p class="search-result" id="ranking-search-result" data-site-copy="note">等待插件数据</p>
                 <div class="search-sort" id="ranking-search-sort" role="group" aria-label="搜索结果排序" hidden>
                   <span>排序</span>
                   <button type="button" data-search-sort="relevance" aria-pressed="true">相关度</button>
@@ -3043,12 +3091,12 @@
                 <a class="github-link" href="https://github.com/dsheval/dsh-top100" aria-label="在 GitHub 打开 dsh-top100" title="GitHub" target="_blank" rel="noopener noreferrer">
                   <svg class="github-logo" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .7a11.3 11.3 0 0 0-3.6 22c.6.1.8-.3.8-.6v-2.2c-3.3.7-4-1.4-4-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.9 1.2 1.9 1.2 1.1 1.9 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-6a4.7 4.7 0 0 1 1.2-3.1c-.1-.3-.5-1.6.1-3.1 0 0 1-.3 3.2 1.2a11 11 0 0 1 5.8 0c2.2-1.5 3.2-1.2 3.2-1.2.6 1.5.2 2.8.1 3.1a4.7 4.7 0 0 1 1.2 3.1c0 4.7-2.8 5.7-5.5 6 .4.4.8 1.1.8 2.2v3.2c0 .4.2.7.8.6A11.3 11.3 0 0 0 12 .7Z"></path></svg>
                 </a>
-                <a class="featured-guide" href="?page=dsh#dsh" data-content-switch="dsh">安装指南 ↗</a>
+                <a class="featured-guide" href="?page=dsh#dsh" data-content-switch="dsh">安装指南 <span aria-hidden="true">→</span></a>
               </div>
-              <p class="plugin-description">把插件榜单带进 DSH，发现、安装和管理插件。</p>
+              <p class="plugin-description" data-site-copy="note">把插件榜单带进 DSH，发现、安装和管理插件。</p>
               <span class="rank-exempt" aria-label="不参与评分">—</span>
             </aside>
-            <p class="status">正在加载 Top 100…</p>
+            <p class="status" data-site-copy="note">正在加载 Top 100…</p>
           </div>
           <p class="sr-only" id="ranking-status" aria-live="polite"></p>
           <button class="load-more" id="load-more" type="button" hidden>继续加载</button>
@@ -3057,30 +3105,30 @@
           <section class="content-view inline-docs" id="docs-view" aria-labelledby="inline-docs-title" hidden>
             <header class="inline-docs-header">
               <h1 class="inline-docs-title" id="inline-docs-title">排名方法</h1>
-              <p class="inline-docs-intro">了解榜单怎么排序、项目如何收录，以及数据如何更新。</p>
+              <p class="inline-docs-intro" data-site-copy="lead">了解榜单怎么排序、项目如何收录，以及数据如何更新。</p>
             </header>
             <div id="inline-docs-host">
-              <p class="docs-loading">正在加载文档…</p>
+              <p class="docs-loading" data-site-copy="note">正在加载文档…</p>
             </div>
           </section>
 
           <section class="content-view inline-docs" id="dsh-view" aria-labelledby="inline-dsh-title" hidden>
             <header class="inline-docs-header">
-              <h1 class="inline-docs-title" id="inline-dsh-title">安装 dsh-top100</h1>
-              <p class="inline-docs-intro">在 DSH 中浏览榜单、搜索和安装插件。</p>
+              <h1 class="inline-docs-title" id="inline-dsh-title">安装指南</h1>
+              <p class="inline-docs-intro" data-site-copy="lead">安装 dsh-top100，在 DSH 中浏览榜单、搜索和安装插件。</p>
             </header>
             <div id="inline-dsh-host">
-              <p class="docs-loading">正在加载接入说明…</p>
+              <p class="docs-loading" data-site-copy="note">正在加载接入说明…</p>
             </div>
           </section>
 
           <section class="content-view inline-docs" id="dsheval-view" aria-labelledby="inline-dsheval-title" hidden>
             <header class="inline-docs-header">
-              <h2 class="inline-docs-title" id="inline-dsheval-title">DSHeval.</h2>
-              <p class="inline-docs-title-zh">新的评测页面。</p>
+              <h1 class="inline-docs-title" id="inline-dsheval-title">关于 DSH-Eval</h1>
+              <p class="inline-docs-title-zh" data-site-copy="lead">公开评测与任务证据</p>
             </header>
             <div id="inline-dsheval-host">
-              <p class="docs-loading">正在加载 DSHeval…</p>
+              <p class="docs-loading" data-site-copy="note">正在加载 DSHeval…</p>
             </div>
           </section>
         </div>
@@ -3115,7 +3163,7 @@
             <svg class="copy-icon" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 1.5v8M4.8 6.7 8 9.9l3.2-3.2M2 12.5h12"></path></svg>
           </button>
         </div>
-        <p class="plugin-description"></p>
+        <p class="plugin-description" data-site-copy="note"></p>
         <div class="plugin-meta" aria-label="项目元数据">
           <span class="meta-updated"></span>
           <span class="meta-growth"></span>
@@ -3413,6 +3461,8 @@
 
       function setContentView(view, { historyMode = "replace", scroll = false } = {}) {
         currentContentView = contentViewNames.has(view) ? view : "ranking";
+        const pageTitles = { ranking: "插件榜单", docs: "排名方法", dsh: "安装指南", dsheval: "关于 DSH-Eval" };
+        document.title = currentContentView === "dsheval" ? "关于 DSH-Eval" : `${pageTitles[currentContentView]} · Top100 · DSH-Eval`;
         const requestedContentView = currentContentView;
         const contentViews = {
           ranking: leaderboardView,
@@ -4275,7 +4325,7 @@
             ? manifest?.datasets?.total?.count ?? matched.length
             : matched.length;
           const migrationStatus = currentView === "top100" && !searchActive && excludedHotSkillCount > 0
-            ? `当前快照：${formatStars(shown.length)} 个已验证插件 · 已排除 ${formatStars(excludedHotSkillCount)} 个 Skills`
+            ? `当前快照：${formatStars(shown.length)} 个插件 · 已排除 ${formatStars(excludedHotSkillCount)} 个 Skills`
             : null;
           searchResult.textContent = searchActive
             ? `匹配 ${formatStars(matched.length)} 个 · ${activeSearchSort === "relevance" ? "按相关度" : "按榜单顺序"} · 显示原榜排名`

--- a/web/public/ranking-method.css
+++ b/web/public/ranking-method.css
@@ -5,7 +5,7 @@ body:has(#docs-view:not([hidden])) .hero {
 
 body:has(#docs-view:not([hidden])) .ranking {
   background: var(--paper);
-  scroll-margin-top: 62px;
+  scroll-margin-top: var(--site-header-height);
 }
 
 body:has(#docs-view:not([hidden])) .ranking-inner,
@@ -42,7 +42,7 @@ body:has(#dsh-view:not([hidden])) .ranking-inner {
 
 #docs-view .toc {
   position: sticky;
-  top: 86px;
+  top: calc(var(--site-header-height) + 24px);
   display: grid;
   grid-template-columns: 1fr;
   margin: 0;
@@ -79,7 +79,7 @@ body:has(#dsh-view:not([hidden])) .ranking-inner {
 
 #docs-view .doc-section {
   padding: 0 0 36px;
-  scroll-margin-top: 86px;
+  scroll-margin-top: calc(var(--site-header-height) + 24px);
 }
 
 #docs-view .doc-section + .doc-section {
@@ -297,14 +297,14 @@ body:has(#dsh-view:not([hidden])) .ranking-inner {
 @media (max-width: 1100px) {
   #docs-view .docs-layout { display: block; }
   #docs-view .toc {
-    top: 62px;
+    top: var(--site-header-height);
     grid-template-columns: repeat(6, minmax(0, 1fr));
     margin-bottom: 28px;
     border: 1px solid var(--line);
     background: var(--paper);
   }
   #docs-view .toc a { justify-content: center; padding-inline: 8px; }
-  #docs-view .doc-section { scroll-margin-top: 130px; }
+  #docs-view .doc-section { scroll-margin-top: calc(var(--site-header-height) + 68px); }
 }
 
 @media (max-width: 640px) {
@@ -314,7 +314,7 @@ body:has(#dsh-view:not([hidden])) .ranking-inner {
   #dsh-view .dsh-copy-button { min-width: 64px; padding-inline: 12px; }
   #docs-view .inline-docs-header { margin-bottom: 22px; padding-bottom: 22px; }
   #docs-view .toc { position: static; grid-template-columns: repeat(3, minmax(0, 1fr)); }
-  #docs-view .doc-section { scroll-margin-top: 78px; }
+  #docs-view .doc-section { scroll-margin-top: calc(var(--site-header-height) + 16px); }
   #docs-view .doc-section h2 { font-size: 21px; }
   #docs-view .card-grid.four { grid-template-columns: 1fr; }
   #docs-view th, #docs-view td { padding: 10px 12px; }

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -6,4 +6,4 @@ Allow: /data/snapshots/
 Allow: /data/rankings-hot.json
 Disallow: /data/
 
-Sitemap: https://www.dsheval.ai/sitemap.xml
+Sitemap: https://dsheval.ai/top100/sitemap.xml

--- a/web/public/site-chrome.css
+++ b/web/public/site-chrome.css
@@ -2,6 +2,9 @@
    Both independently deployed sites use the same shell without a runtime dependency. */
 :root {
   --site-header-height: 64px;
+  --site-display-font: 'Iowan Old Style', Baskerville, 'Times New Roman', 'Songti SC', serif;
+  --site-label-font: 'SFMono-Regular', 'Roboto Mono', Consolas, monospace;
+  --site-home-title-size: clamp(54px, 6vw, 88px);
   --site-ui-font: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Microsoft YaHei', sans-serif;
 }
 .dsh-site-header, .dsh-site-footer {
@@ -55,7 +58,7 @@
 .dsh-footer-intro p { margin: 0; color: var(--dsh-muted); font-size: 14px; font-weight: 400; line-height: 1.7; }
 .dsh-footer-links { display: flex; align-items: center; flex-wrap: wrap; gap: 8px 24px; margin-left: auto; }
 .dsh-footer-links a { display: inline-flex; align-items: center; gap: 4px; min-height: 44px; color: var(--dsh-muted); font-size: 14px; font-weight: 400; line-height: 20px; white-space: nowrap; }
-.dsh-copyright { color: var(--dsh-muted); font-size: 12px; line-height: 20px; font-weight: 400; white-space: nowrap; }
+.dsh-copyright { color: var(--dsh-muted); font-size: 14px; line-height: 20px; font-weight: 400; white-space: nowrap; }
 .dsh-visually-hidden { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip-path: inset(50%); white-space: nowrap; border: 0; }
 @media (max-width: 1100px) {
   .dsh-footer-inner { display: grid; grid-template-columns: 1fr auto; gap: 8px 24px; }
@@ -73,4 +76,291 @@
   .dsh-footer-intro { display: block; }
   .dsh-footer-intro p { margin-top: 4px; }
   .dsh-footer-links { gap: 4px 20px; }
+}
+
+/* The two homepages share display typography; other page titles are unchanged. */
+:is(.homepage-hero-copy, .hero-copy, .hero-summary) > h1.dsh-home-title {
+  font-family: var(--site-display-font);
+  font-size: var(--site-home-title-size);
+  font-weight: 700;
+  font-style: normal;
+  line-height: 1.03;
+  letter-spacing: -.03em;
+}
+@media (max-width: 720px) {
+  :root { --site-home-title-size: clamp(36px, 11.5vw, 62px); }
+}
+
+/* Homepage spacing; all English heading labels share the roles below. */
+:is(.homepage-hero-copy, .hero-copy) > p.dsh-home-eyebrow {
+  margin: 0 0 24px;
+}
+.dsh-home-eyebrow > span, .inner-page-hero-eyebrow > span { white-space: nowrap; }
+
+/* Explicit English labels cover page, section and card headings on both sites.
+   lang also gives assistive technology the correct pronunciation context. */
+:is(main#main-content, main#top, main) [data-site-label][lang="en"] {
+  color: #126657;
+  font-family: var(--site-label-font);
+  font-size: 12px;
+  font-weight: 600;
+  font-style: normal;
+  line-height: 1.5;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+:is(main#main-content, main#top, main) [data-site-label="page"][lang="en"] {
+  font-size: 14px;
+}
+@media (max-width: 720px) {
+  :is(main#main-content, main#top, main) [data-site-label="page"][lang="en"] {
+    font-size: 12px;
+  }
+}
+
+/* Homepage layout; typography comes from the shared reading roles below. */
+:is(.homepage-hero-copy, .hero-copy) > p.dsh-home-description {
+  max-width: 650px;
+  margin: 28px 0 0;
+}
+
+/* Reading roles are shared by every page and by dynamically loaded guides.
+   Keep prose separate from display titles, interface labels and numeric data.
+   The main scope takes precedence over legacy page-specific typography. */
+:root {
+  --site-copy-color: #4f5e59;
+  --site-copy-lead-size: clamp(17px, 1.45vw, 20px);
+  --site-copy-body-size: 16px;
+  --site-copy-note-size: 14px;
+}
+:is(main#main-content, main#top, main) [data-site-copy] {
+  color: var(--site-copy-color);
+  font-family: var(--site-ui-font);
+  font-size: var(--site-copy-body-size);
+  font-weight: 400;
+  font-style: normal;
+  line-height: 1.75;
+  letter-spacing: normal;
+  text-transform: none;
+  overflow-wrap: anywhere;
+}
+:is(main#main-content, main#top, main) [data-site-copy="lead"] {
+  font-size: var(--site-copy-lead-size);
+  line-height: 1.65;
+}
+:is(main#main-content, main#top, main) [data-site-copy="note"] {
+  font-size: var(--site-copy-note-size);
+  line-height: 1.6;
+}
+.dossier-highlight, .result-report-finding, .memory-protocol-note {
+  --site-copy-color: #126657;
+}
+
+/* Shared controls: actions, inputs and badges use the interface face.
+   Editorial labels and benchmark numbers retain their separate type roles. */
+:root {
+  --site-control-height: 44px;
+  --site-control-accent: #126657;
+  --site-control-hover: #174942;
+  --site-control-soft: #e0ede8;
+  --site-control-line: rgba(19, 32, 28, .24);
+}
+:is(main#main-content, main#top, main) :is(
+  button, input, select, .homepage-hero-actions a, .hero-actions a,
+  .plugin-action, .skill-filter, .dossier-link, .method-results-link,
+  .verification-protocol-link, .report-resource-bar a, .report-extra-resources a,
+  .report-next-links a, .research-method-links a, .method-capabilities a
+) {
+  font-family: var(--site-ui-font);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 20px;
+  letter-spacing: normal;
+  text-transform: none;
+}
+:is(main#main-content, main#top, main) :is(
+  .homepage-hero-actions a, .hero-actions a, .hero-search-control button,
+  .hero-command-row button, .dsh-copy-button, .load-more, .plugin-action,
+  .skill-filter, .install-filter, .view-tab, .category-option,
+  .memory-metric-switch button, .evaluation-carousel-labels button, .search-sort button
+) {
+  box-sizing: border-box;
+  min-height: var(--site-control-height);
+  border-radius: 0;
+}
+:is(main#main-content, main#top, main) :is(.homepage-hero-actions a, .hero-actions a, .load-more) {
+  padding: 10px 18px;
+  border: 1px solid var(--site-control-accent);
+  box-shadow: none;
+  gap: 8px;
+  text-decoration: none;
+}
+:is(main#main-content, main#top, main) :is(
+  .homepage-primary-link, .hero-link, .hero-search-control button,
+  .hero-command-row button, .dsh-copy-button, .plugin-action.install-action
+) {
+  color: #fff;
+  background: var(--site-control-accent);
+  border-color: var(--site-control-accent);
+}
+:is(main#main-content, main#top, main) :is(
+  .homepage-primary-link, .hero-link, .hero-search-control button,
+  .hero-command-row button, .dsh-copy-button, .plugin-action.install-action
+):hover {
+  color: #fff;
+  background: var(--site-control-hover);
+  border-color: var(--site-control-hover);
+}
+:is(main#main-content, main#top, main) :is(.homepage-secondary-link, .hero-placeholder, .load-more) {
+  color: var(--site-control-accent);
+  background: transparent;
+  transform: none;
+}
+:is(main#main-content, main#top, main) :is(.homepage-secondary-link, .hero-placeholder, .load-more):hover {
+  color: var(--site-control-accent);
+  background: var(--site-control-soft);
+}
+:is(main#main-content, main#top, main) :is(.view-tab, .category-option, .memory-metric-switch button, .search-sort button) {
+  padding-inline: 12px;
+  color: #4f5e59;
+  background: transparent;
+}
+:is(main#main-content, main#top, main) :is(.view-tab, .category-option, .memory-metric-switch button, .search-sort button):hover {
+  color: var(--site-control-accent);
+  background: var(--site-control-soft);
+}
+:is(main#main-content, main#top, main) :is(.view-tab[aria-selected="true"], .memory-metric-switch button[aria-pressed="true"], .search-sort button[aria-pressed="true"]) {
+  color: #fff;
+  background: var(--site-control-accent);
+  box-shadow: none;
+}
+:is(main#main-content, main#top, main) :is(.category-option, .install-filter)[aria-pressed="true"] {
+  color: var(--site-control-accent);
+  background: var(--site-control-soft);
+  box-shadow: inset 0 -2px var(--site-control-accent);
+}
+:is(main#main-content, main#top, main) .evaluation-carousel-pagination button {
+  width: var(--site-control-height);
+  height: var(--site-control-height);
+  border: 1px solid var(--site-control-line);
+  font-size: 20px;
+}
+:is(main#main-content, main#top, main) :is(input[type="search"], select) {
+  min-height: var(--site-control-height);
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 24px;
+  border-radius: 0;
+}
+:is(main#main-content, main#top, main) input::placeholder {
+  color: #687772;
+  font-weight: 400;
+  opacity: 1;
+}
+:is(main#main-content, main#top, main) :is(.hero-search-control, .search-input, .controls, .install-filter, .view-tabs, .category-options, .memory-metric-switch) {
+  border-color: var(--site-control-line);
+  border-radius: 0;
+}
+:is(main#main-content, main#top, main) .hero-search-control { box-shadow: none; }
+:is(main#main-content, main#top, main) :is(.search-clear, .description-toggle) {
+  min-height: 32px;
+  font-size: 12px;
+}
+:is(main#main-content, main#top, main) :is(.release-badge, .trust-pill, .type-pill, .skill-kind, .result-report-status, .verification-current-marker, .research-task-status, .dossier-head > span:last-child) {
+  box-sizing: border-box;
+  font-family: var(--site-ui-font);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 18px;
+  letter-spacing: normal;
+  text-transform: none;
+}
+:is(main#main-content, main#top, main) :is(.release-badge, .trust-pill, .type-pill, .skill-kind, .result-report-status, .verification-current-marker) {
+  min-height: 24px;
+  padding: 2px 7px;
+  border: 1px solid var(--site-control-line);
+  border-radius: 0;
+}
+:is(main#main-content, main#top, main) :is(.release-badge, .result-report-status, .verification-current-marker, .trust-pill[data-level="install-source"]) {
+  color: var(--site-control-accent);
+  background: var(--site-control-soft);
+  border-color: rgba(18, 102, 87, .3);
+}
+:is(main#main-content, main#top, main) :is(a, button, input, select, summary, .dsh-copy-button, .plugin-action):focus-visible {
+  outline: 2px solid var(--site-control-accent);
+  outline-offset: 3px;
+}
+/* Inset focus remains visible inside clipped search and filter containers. */
+:is(main#main-content, main#top, main) :is(input, .category-option, .view-tab):focus-visible {
+  outline-offset: -3px;
+}
+/* Search fields keep their neutral boundary when focused. */
+:is(main#main-content, main#top, main) input[type="search"]:focus {
+  outline: none;
+  box-shadow: none;
+  border-color: var(--site-control-line);
+}
+:is(main#main-content, main#top, main) :is(button, .plugin-action):disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+@media (pointer: coarse) {
+  :is(main#main-content, main#top, main) :is(.search-clear, .description-toggle, .github-link) {
+    min-width: 44px;
+    min-height: 44px;
+  }
+}
+
+/* Compact category labels leave room for their icon and count. */
+:is(main#main-content, main#top, main) button.category-option { font-size: 13px; }
+
+/* Keep labels intact in compact report and category controls. */
+:is(main#main-content, main#top, main) .memory-metric-switch button {
+  padding-inline: 8px;
+  white-space: nowrap;
+}
+@media (min-width: 641px) and (max-width: 1100px) {
+  :is(main#main-content, main#top, main) button.category-option { padding-inline: 8px; }
+}
+
+/* Content title roles are independent of heading depth and shared by both sites. */
+:root {
+  --site-page-title-size: clamp(48px, 5vw, 64px);
+  --site-section-title-size: 32px;
+  --site-group-title-size: 22px;
+}
+:is(main#main-content, main#top, main) [data-site-title] {
+  font-family: var(--site-ui-font);
+  font-style: normal;
+  font-weight: 600;
+  letter-spacing: -.02em;
+  text-wrap: balance;
+}
+:is(main#main-content, main#top, main) [data-site-title="page"] {
+  font-family: var(--site-display-font);
+  font-size: var(--site-page-title-size);
+  font-weight: 650;
+  line-height: 1.15;
+  letter-spacing: -.03em;
+}
+:is(main#main-content, main#top, main) [data-site-title="section"] {
+  font-size: var(--site-section-title-size);
+  font-weight: 650;
+  line-height: 1.3;
+}
+:is(main#main-content, main#top, main) [data-site-title="group"] {
+  font-size: var(--site-group-title-size);
+  line-height: 1.4;
+}
+:is(main#main-content, main#top, main) [data-site-title="minor"] {
+  font-size: 18px;
+  line-height: 1.5;
+}
+.verification-disclosure-title { margin: 0; }
+@media (max-width: 720px) {
+  :root {
+    --site-page-title-size: clamp(28px, 8.6vw, 40px);
+    --site-section-title-size: 26px;
+    --site-group-title-size: 20px;
+  }
 }

--- a/web/public/site-chrome.css
+++ b/web/public/site-chrome.css
@@ -1,0 +1,76 @@
+/* Shared verbatim with dsh-top100/web/public/site-chrome.css.
+   Both independently deployed sites use the same shell without a runtime dependency. */
+:root {
+  --site-header-height: 64px;
+  --site-ui-font: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Microsoft YaHei', sans-serif;
+}
+.dsh-site-header, .dsh-site-footer {
+  --dsh-paper: #f7f9f8;
+  --dsh-ink: #13201c;
+  --dsh-muted: #4f5e59;
+  --dsh-accent: #126657;
+  --dsh-deep: #174942;
+  --dsh-line: rgba(19, 32, 28, .12);
+  font-family: var(--site-ui-font);
+  color: var(--dsh-ink);
+  background: var(--dsh-paper);
+  letter-spacing: normal;
+  text-transform: none;
+}
+.dsh-site-header *, .dsh-site-footer * { box-sizing: border-box; }
+.dsh-site-container { width: min(1380px, calc(100% - 48px)); margin-inline: auto; }
+.dsh-site-header {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  height: var(--site-header-height);
+  box-sizing: border-box;
+  border-bottom: 1px solid var(--dsh-line);
+}
+.dsh-header-inner { position: relative; display: flex; align-items: center; justify-content: space-between; gap: 32px; height: 63px; }
+.dsh-site-header a, .dsh-site-footer a { color: inherit; text-decoration: none; font-family: inherit; }
+.dsh-brand-link { display: inline-flex; flex: none; align-items: center; min-height: 44px; }
+.dsh-brand { display: inline-flex; align-items: baseline; gap: 7px; white-space: nowrap; font-size: 22px; line-height: 1; letter-spacing: -.04em; }
+.dsh-brand strong, .dsh-brand b { font-size: inherit; font-weight: 800; }
+.dsh-brand > span { color: var(--dsh-accent); font-weight: 650; }
+.dsh-brand b { color: var(--dsh-deep); }
+.dsh-desktop-nav { display: flex; align-items: stretch; align-self: stretch; gap: 32px; }
+.dsh-desktop-nav a { display: inline-flex; align-items: center; font-size: 14px; line-height: 20px; font-weight: 600; color: var(--dsh-muted); white-space: nowrap; }
+.dsh-desktop-nav a:hover, .dsh-footer-links a:hover { color: var(--dsh-accent); }
+.dsh-desktop-nav a[aria-current='page'] { color: var(--dsh-ink); box-shadow: inset 0 -2px var(--dsh-accent); }
+.dsh-site-header a:focus-visible, .dsh-site-header summary:focus-visible, .dsh-site-footer a:focus-visible { outline: 2px solid var(--dsh-accent); outline-offset: 4px; }
+.dsh-mobile-menu { display: none; }
+.dsh-mobile-menu summary { display: flex; min-height: 44px; align-items: center; gap: 12px; list-style: none; font-size: 14px; font-weight: 600; cursor: pointer; }
+.dsh-mobile-menu summary::-webkit-details-marker { display: none; }
+.dsh-menu-icon { position: relative; width: 18px; height: 10px; border-block: 1.5px solid currentColor; }
+.dsh-mobile-menu[open] .dsh-menu-icon { height: 0; border-bottom: 0; transform: rotate(45deg); }
+.dsh-mobile-menu[open] .dsh-menu-icon::after { content: ''; position: absolute; width: 18px; border-top: 1.5px solid currentColor; top: -1.5px; transform: rotate(90deg); }
+.dsh-mobile-menu nav { position: absolute; top: 63px; left: -20px; right: -20px; padding: 8px 20px 16px; border-bottom: 1px solid var(--dsh-line); background: var(--dsh-paper); box-shadow: 0 16px 24px rgba(19,32,28,.06); }
+.dsh-mobile-menu nav a { display: flex; min-height: 48px; align-items: center; padding-inline: 12px; font-size: 15px; font-weight: 600; }
+.dsh-mobile-menu a[aria-current='page'] { color: var(--dsh-accent); background: #e5ebe8; box-shadow: inset 2px 0 var(--dsh-accent); }
+.dsh-site-footer { border-top: 1px solid var(--dsh-line); }
+.dsh-footer-inner { display: flex; align-items: center; justify-content: space-between; gap: 24px 32px; min-height: 96px; padding-block: 20px; }
+.dsh-footer-intro { display: flex; align-items: center; gap: 24px; }
+.dsh-site-footer .dsh-brand { font-size: 18px; }
+.dsh-footer-intro p { margin: 0; color: var(--dsh-muted); font-size: 14px; font-weight: 400; line-height: 1.7; }
+.dsh-footer-links { display: flex; align-items: center; flex-wrap: wrap; gap: 8px 24px; margin-left: auto; }
+.dsh-footer-links a { display: inline-flex; align-items: center; gap: 4px; min-height: 44px; color: var(--dsh-muted); font-size: 14px; font-weight: 400; line-height: 20px; white-space: nowrap; }
+.dsh-copyright { color: var(--dsh-muted); font-size: 12px; line-height: 20px; font-weight: 400; white-space: nowrap; }
+.dsh-visually-hidden { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip-path: inset(50%); white-space: nowrap; border: 0; }
+@media (max-width: 1100px) {
+  .dsh-footer-inner { display: grid; grid-template-columns: 1fr auto; gap: 8px 24px; }
+  .dsh-footer-intro { grid-column: 1 / -1; }
+  .dsh-footer-links { margin-left: 0; }
+}
+@media (max-width: 760px) {
+  .dsh-site-container { width: calc(100% - 40px); }
+  .dsh-desktop-nav { display: none; }
+  .dsh-mobile-menu { display: block; }
+  .dsh-brand { font-size: 21px; }
+}
+@media (max-width: 600px) {
+  .dsh-footer-inner { grid-template-columns: minmax(0, 1fr); padding-block: 24px; gap: 12px; }
+  .dsh-footer-intro { display: block; }
+  .dsh-footer-intro p { margin-top: 4px; }
+  .dsh-footer-links { gap: 4px 20px; }
+}

--- a/web/public/site-controls.css
+++ b/web/public/site-controls.css
@@ -124,7 +124,6 @@
 
 .hero-actions { margin-top: 24px; }
 .hero-actions :is(.hero-link, .hero-placeholder) { line-height: 1.5; }
-.wordmark img { border: 0; border-radius: 0; background: transparent; object-fit: contain; }
 @media (prefers-reduced-motion: reduce) {
   .hero-actions a { transition: none; }
 }
@@ -132,14 +131,59 @@
 /* Site-wide typography, including the responsive variants. */
 .hero .eyebrow { color: var(--hero-accent); font: 700 17px var(--mono); letter-spacing: .045em; }
 :is(.hero-description, .hero-summary .hero-copy) { color: var(--muted); font: 400 clamp(17px, 1.55vw, 21px)/1.5 var(--sans); }
-.footer { display: flex; min-height: 96px; padding: 24px max(24px, calc((100vw - var(--content)) / 2)); align-items: center; justify-content: space-between; gap: 30px; border-top: 1px solid #6f837c; background: #2b443d; color: var(--paper); font: 700 12px/1.6 var(--mono); letter-spacing: .05em; text-transform: uppercase; }
-.footer span:last-child { color: #c9d6d1; }
 @media (max-width: 720px) {
   .hero .eyebrow { font-size: 13px; }
-  .footer { display: block; }
-  .footer span { display: block; }
-  .footer span:last-child { margin-top: 8px; }
 }
 
 .nav-links a[aria-current="page"] { color: var(--hero-accent); }
 .nav-links a[aria-current="page"]::after { opacity: 1; transform: scaleX(1); }
+
+/* Top100 controls belong to the page, below the shared site header. */
+[id] { scroll-margin-top: calc(var(--site-header-height) + 16px); }
+.top100-section-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 32px;
+  width: 100%;
+  min-height: 52px;
+  margin: 0;
+  padding: 0 max(24px, calc((100% - 1380px) / 2));
+  border-bottom: 1px solid rgba(19, 32, 28, .12);
+  background: #f7f9f8;
+  font-family: var(--site-ui-font);
+  letter-spacing: normal;
+}
+.top100-section-title { display: inline-flex; align-items: center; gap: 7px; flex: none; min-height: 52px; color: #13201c; font: 650 18px/1.2 var(--site-ui-font); letter-spacing: -.025em; text-decoration: none; }
+.top100-section-title img { display: block; flex: none; }
+.top100-section-nav .nav-links { display: flex; min-width: 0; align-items: center; gap: 28px; overflow-x: auto; }
+.top100-section-nav .nav-links a:nth-child(n) { display: inline-flex; align-items: center; gap: 4px; flex: none; position: relative; min-height: 52px; padding: 0; color: #4f5e59; font: 500 13px/20px var(--site-ui-font); text-decoration: none; white-space: nowrap; }
+.top100-section-nav .nav-links a::after { display: none; }
+.top100-section-nav .nav-links a:hover { color: #126657; }
+.top100-section-nav .nav-links a[aria-current="page"] { color: #126657; font-weight: 600; box-shadow: inset 0 -2px #126657; }
+.top100-section-nav a:focus-visible { outline: 2px solid #126657; outline-offset: -2px; }
+.top100-section-nav + .hero .hero-inner { padding-top: 64px; }
+.ranking-source-note { margin: 12px 0 0; color: var(--muted); font: 400 13px/1.6 var(--sans); }
+@media (max-width: 900px) {
+  .top100-section-nav { gap: 24px; }
+  .top100-section-nav .nav-links { gap: 22px; }
+}
+@media (max-width: 760px) {
+  .top100-section-nav { padding-inline: 20px; }
+}
+@media (max-width: 680px) {
+  .top100-section-nav { position: relative; flex-wrap: wrap; gap: 0; }
+  .top100-section-nav .nav-links { flex-basis: 100%; gap: 16px; border-top: 1px solid rgba(19, 32, 28, .08); }
+  .top100-section-nav .nav-links a:nth-child(n) { min-height: 44px; }
+  .top100-section-nav .nav-links a:last-child { position: absolute; top: 0; right: 20px; min-height: 52px; }
+  .top100-section-nav + .hero .hero-inner { padding-top: 40px; }
+}
+
+/* Retain real grid spacing when the plugin hero stacks on small screens. */
+@media (max-width: 720px) {
+  .top100-section-nav + .hero .hero-inner { display: grid; grid-template-columns: minmax(0, 1fr); gap: 40px; }
+}
+@media (max-width: 360px) {
+  .top100-section-nav .nav-links { gap: 10px; }
+  .hero .hero-copy h1, .hero .hero-summary h1 { font-size: clamp(32px, 11.5vw, 40px); }
+}

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://www.dsheval.ai/</loc>
-    <changefreq>daily</changefreq>
-    <priority>1.0</priority>
-  </url>
+  <url><loc>https://dsheval.ai/top100/</loc></url>
+  <url><loc>https://dsheval.ai/top100/skills.html</loc></url>
 </urlset>

--- a/web/public/skills.html
+++ b/web/public/skills.html
@@ -4,7 +4,10 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#d9e7e2" />
-    <meta name="description" content="独立浏览 DSHEval 收录的 Agent Skills；Skills 不参与 DSH 插件排名。" />
+    <meta name="description" content="浏览 DSH-Eval 旗下 Top100 收录的 Agent Skills；收录不代表已通过能力评测，Skills 不参与插件排名。" />
+    <link rel="canonical" href="https://dsheval.ai/top100/skills.html" />
+    <meta property="og:url" content="https://dsheval.ai/top100/skills.html" />
+    <meta property="og:site_name" content="DSH-Eval" />
     <title>Skills 榜单 · dsh-top100</title>
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="./install-console.css" />
@@ -43,25 +46,9 @@
       main { background: var(--section); }
       button, input, select { font: inherit; }
 
-      .nav-shell {
-        position: sticky;
-        z-index: 20;
-        top: 0;
-        border-bottom: 1px solid rgba(23, 33, 31, 0.12);
-        background: color-mix(in srgb, var(--paper) 94%, transparent);
-        backdrop-filter: blur(12px);
-      }
-      .nav {
-        display: flex;
-        width: min(calc(100% - 48px), var(--content));
-        min-height: 62px;
-        margin: auto;
-        align-items: center;
-        justify-content: space-between;
-        gap: 32px;
-      }
-      .wordmark { display: inline-flex; align-items: center; gap: 10px; font-size: 18px; font-weight: 800; letter-spacing: -0.03em; text-decoration: none; }
-      .wordmark img { display: block; width: 30px; height: 30px; border: 1px solid rgba(23, 33, 31, 0.14); border-radius: 50%; background: var(--card); object-fit: cover; }
+
+
+
       .nav-links { display: flex; align-items: center; gap: clamp(14px, 2vw, 28px); font-size: 13px; font-weight: 700; }
       .nav-links a { position: relative; padding: 22px 0 19px; color: var(--muted); text-decoration: none; }
       .nav-links a::after { position: absolute; height: 2px; inset: auto 0 13px; background: var(--accent); content: ""; opacity: 0; transform: scaleX(0.4); transition: opacity 150ms ease, transform 150ms ease; }
@@ -104,7 +91,7 @@
         line-height: 1.5;
       }
 
-      .directory { min-height: 100vh; padding: 64px 0 96px; scroll-margin-top: 62px; }
+      .directory { min-height: 100vh; padding: 64px 0 96px; scroll-margin-top: var(--site-header-height); }
       .directory-head {
         display: flex;
         align-items: end;
@@ -219,21 +206,19 @@
       .github-logo { display: block; width: 13px; height: 13px; object-fit: contain; }
       .empty { margin: 0; padding: 52px 20px; border: 1px solid var(--line); border-top: 0; background: var(--card); text-align: center; color: var(--muted); }
 
-      footer { padding: 34px 20px; color: #c9d6d1; background: #2b443d; text-align: center; font: 700 12px/1.6 var(--mono); }
-
       @media (max-width: 980px) {
         .nav-links a:nth-child(4) { display: none; }
         .hero-inner { grid-template-columns: 1fr; gap: 44px; padding: 68px 0 70px; }
         .hero-side { width: 100%; max-width: 700px; }
       }
       @media (min-width: 721px) {
-        .skill-list-head { position: sticky; z-index: 8; top: 62px; box-shadow: 0 8px 18px rgba(23, 33, 31, 0.08); }
+        .skill-list-head { position: sticky; z-index: 8; top: var(--site-header-height); box-shadow: 0 8px 18px rgba(23, 33, 31, 0.08); }
       }
       @media (max-width: 960px) {
         .skill-list-head, .skill-card { grid-template-columns: 54px minmax(190px, 0.78fr) minmax(220px, 1fr) 118px; gap: 16px; }
       }
       @media (max-width: 720px) {
-        .nav { width: min(calc(100% - 28px), var(--content)); gap: 14px; }
+
         .nav-links { gap: 13px; }
         .nav-links a { font-size: 12px; }
         .nav-links a:nth-child(n + 3) { display: none; }
@@ -265,23 +250,32 @@
     </style>
     <link rel="stylesheet" href="./category-system.css" />
     <link rel="stylesheet" href="./ranking-rows.css" />
-    <link rel="stylesheet" href="./site-controls.css" />
+    <link rel="stylesheet" href="./site-controls.css?v=20260905-nav2" />
+    <link rel="stylesheet" href="./site-chrome.css?v=20260905-nav2" />
   </head>
   <body>
-    <div class="nav-shell">
-      <nav class="nav" aria-label="主导航">
-        <a class="wordmark" href="./index.html"><img src="./favicon.svg" alt="" /><span>dsh-top100</span></a>
+    <header class="dsh-site-header">
+      <div class="dsh-site-container dsh-header-inner">
+        <a class="dsh-brand-link" href="/" aria-label="DSH-Eval 首页"><span class="dsh-brand" translate="no"><strong>DSH</strong><span aria-hidden="true">/</span><b>EVAL</b></span></a>
+        <nav class="dsh-desktop-nav" aria-label="DSH-Eval 主导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/faq">常见问题</a></nav>
+        <details class="dsh-mobile-menu">
+          <summary>菜单<span class="dsh-menu-icon" aria-hidden="true"></span></summary>
+          <nav aria-label="DSH-Eval 移动端导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/faq">常见问题</a></nav>
+        </details>
+      </div>
+    </header>
+
+    <main>
+      <nav class="top100-section-nav" aria-label="Top100 栏目导航">
+        <a class="top100-section-title" href="./"><img src="./assets/dsh-top100-mark.svg" width="28" height="28" alt="" /><span>dsh-top100</span></a>
         <div class="nav-links">
           <a href="./index.html#ranking">插件榜单</a>
           <a href="./skills.html#ranking" aria-current="page">Skills 榜单</a>
           <a href="./index.html?page=dsh#dsh">安装指南</a>
           <a href="./index.html?page=docs#docs">排名方法</a>
-          <a href="https://github.com/dsheval/dsh-top100" target="_blank" rel="noopener noreferrer">GitHub</a>
+          <a href="https://github.com/dsheval/dsh-top100" target="_blank" rel="noopener noreferrer">GitHub <span aria-hidden="true">↗</span></a>
         </div>
       </nav>
-    </div>
-
-    <main>
       <section class="hero">
         <div class="hero-inner">
           <div class="hero-summary">
@@ -317,7 +311,7 @@
 
       <section class="directory" id="ranking" aria-labelledby="directory-title">
         <header class="directory-head">
-          <div><h2 id="directory-title">Skills 榜单</h2><p>按 GitHub Stars 排序，支持搜索和分类筛选。Skills 独立展示，不参与插件 Top 100。</p></div>
+          <div><h2 id="directory-title">Skills 榜单</h2><p>按 GitHub Stars 排序，支持搜索和分类筛选。Skills 独立展示，不参与插件 Top 100。</p><p class="ranking-source-note">数据来自公开项目信息与 GitHub 指标。优先展示整理后的中文简介，缺少时保留项目原文。</p></div>
           <p class="updated" id="updated">更新于：加载中</p>
         </header>
         <div class="category-panel" id="skill-category-filter-panel">
@@ -334,11 +328,21 @@
 
         </div>
         <p class="status" id="status" aria-live="polite">正在读取 Skills 目录…</p>
-        <div class="skill-list-head" aria-hidden="true"><span>排名</span><span>Skill</span><span>中文简介</span><span class="signal-head">更新与增长</span><span>GitHub Stars</span></div>
+        <div class="skill-list-head" aria-hidden="true"><span>排名</span><span>Skill</span><span>项目简介</span><span class="signal-head">更新与增长</span><span>GitHub Stars</span></div>
         <div class="skill-grid" id="skill-grid"></div>
       </section>
     </main>
-    <footer class="footer"><span>dsh-top100 · Skills leaderboard</span><span>Verified sources · AI Chinese summaries · Daily updates</span></footer>
+    <footer class="dsh-site-footer">
+      <div class="dsh-site-container dsh-footer-inner">
+        <div class="dsh-footer-intro"><a class="dsh-brand-link" href="/" aria-label="DSH-Eval 首页"><span class="dsh-brand" translate="no"><strong>DSH</strong><span aria-hidden="true">/</span><b>EVAL</b></span></a><p>公开评测，发现值得关注的项目。</p></div>
+        <nav class="dsh-footer-links" aria-label="页脚导航">
+          <a href="https://github.com/dsheval/dsh-eval" target="_blank" rel="noopener noreferrer">评测源码 <span aria-hidden="true">↗</span><span class="dsh-visually-hidden">（新窗口打开）</span></a>
+          <a href="https://github.com/dsheval/dsh-top100" target="_blank" rel="noopener noreferrer">Top100 源码 <span aria-hidden="true">↗</span><span class="dsh-visually-hidden">（新窗口打开）</span></a>
+          <a href="/faq">常见问题</a>
+        </nav>
+        <span class="dsh-copyright">© 2026 DSH-Eval</span>
+      </div>
+    </footer>
 
     <template id="featured-skill-template">
             <aside class="skill-card featured-skill" aria-label="本站出品，不参与排名">
@@ -382,9 +386,9 @@
         describedBy: "skill-category-description",
       });
 
-      const MANIFEST_URL = "./data/manifest.json";
-      const LEGACY_SKILLS_URL = "./data/rankings-skills.json";
-      const LEGACY_FULL_URL = "./data/rankings.json";
+      const MANIFEST_URL = "/data/manifest.json";
+      const LEGACY_SKILLS_URL = "/data/rankings-skills.json";
+      const LEGACY_FULL_URL = "/data/rankings.json";
       const grid = document.querySelector("#skill-grid");
       const template = document.querySelector("#skill-template");
       const search = document.querySelector("#search");
@@ -447,10 +451,15 @@
             `${categoryLabels[category] ?? "全部分类"}，${formatNumber(count)} 个 Skills`
           );
         }
+        if (!categoryDescription.hidden) {
+          const describedButton = categoryButtons.find((button) => button.dataset.category === categoryDescription.dataset.category);
+          if (describedButton) showCategoryDescription(describedButton);
+        }
       }
 
       function showCategoryDescription(button) {
         const category = button.dataset.category;
+        categoryDescription.dataset.category = category;
         const count = button.querySelector("[data-category-count]").textContent;
         categoryDescriptionTitle.textContent = `${categoryLabels[category] ?? "全部分类"} · ${count} 个 Skills`;
         categoryDescriptionBody.textContent = categoryDescriptions[category];

--- a/web/public/skills.html
+++ b/web/public/skills.html
@@ -8,7 +8,7 @@
     <link rel="canonical" href="https://dsheval.ai/top100/skills.html" />
     <meta property="og:url" content="https://dsheval.ai/top100/skills.html" />
     <meta property="og:site_name" content="DSH-Eval" />
-    <title>Skills 榜单 · dsh-top100</title>
+    <title>Skills 榜单 · Top100 · DSH-Eval</title>
     <link rel="icon" href="./favicon.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="./install-console.css" />
     <style>
@@ -247,11 +247,24 @@
         .skill-card:hover .stars { transform: none; }
         .stars::after { display: none; }
       }
+      /* Keep the Skills directory aligned with Top100's original controls. */
+      #ranking.directory .category-option { min-height: 50px; padding-inline: 12px; font: 800 13px/20px var(--sans); }
+      #ranking.directory .category-option[aria-pressed="true"] { color: var(--ink); background: var(--section-strong); box-shadow: inset 0 -3px 0 var(--accent); }
+      #ranking #search { font: 500 14px/1.4 var(--sans); letter-spacing: 0.01em; }
+      #ranking #search::placeholder { font-weight: 500; }
+      #ranking #search:focus { outline: none; box-shadow: none; }
+      @media (min-width: 641px) and (max-width: 1100px) {
+        #ranking.directory .category-option { padding-inline: 10px; }
+      }
+      @media (max-width: 640px) {
+        #ranking.directory .category-option { min-height: 48px; padding-inline: 11px; font-size: 12px; }
+        #ranking #search { font-size: 16px; }
+      }
     </style>
     <link rel="stylesheet" href="./category-system.css" />
     <link rel="stylesheet" href="./ranking-rows.css" />
     <link rel="stylesheet" href="./site-controls.css?v=20260905-nav2" />
-    <link rel="stylesheet" href="./site-chrome.css?v=20260905-nav2" />
+    <link rel="stylesheet" href="./site-chrome.css?v=20260905-type8c" />
   </head>
   <body>
     <header class="dsh-site-header">
@@ -279,9 +292,9 @@
       <section class="hero">
         <div class="hero-inner">
           <div class="hero-summary">
-          <p class="eyebrow">Explore · Reuse · Compose</p>
-          <h1><span>发现值得复用的</span><span>Agent Skills。</span></h1>
-          <p class="hero-copy">按用途、分类和 GitHub Stars 发现可复用的工作方法，让 Agent 更好地完成你的任务。</p>
+          <p class="eyebrow" data-site-label="page" lang="en">Explore · Reuse · Compose</p>
+          <h1><span>发现值得复用的</span><span>Agent Skills</span></h1>
+          <p class="hero-copy" data-site-copy="lead">按用途、分类和 GitHub Stars 发现可复用的工作方法，让 Agent 更好地完成你的任务。</p>
           <div class="hero-actions"><a class="hero-link hero-content-switch is-active" href="#ranking">浏览 Skills 榜单</a><a class="hero-placeholder" href="./index.html?page=dsh#dsh">安装到 DSH</a></div>
           </div>
           <div class="hero-side">
@@ -303,7 +316,7 @@
                   data-copy-command="npx @deepseek-ai/dsh plugin --profile web add @dsheval/dsh-top100-plugin@1.3.1"
                 >复制</button>
               </div>
-              <p class="install-console-note">命令固定安装当前版排行插件。使用方法请查看<a href="./index.html?page=dsh#dsh">安装指南</a>。</p>
+              <p class="install-console-note" data-site-copy="note">命令固定安装当前版排行插件。使用方法请查看<a href="./index.html?page=dsh#dsh">安装指南</a>。</p>
             </aside>
           </div>
         </div>
@@ -311,7 +324,7 @@
 
       <section class="directory" id="ranking" aria-labelledby="directory-title">
         <header class="directory-head">
-          <div><h2 id="directory-title">Skills 榜单</h2><p>按 GitHub Stars 排序，支持搜索和分类筛选。Skills 独立展示，不参与插件 Top 100。</p><p class="ranking-source-note">数据来自公开项目信息与 GitHub 指标。优先展示整理后的中文简介，缺少时保留项目原文。</p></div>
+          <div><h2 id="directory-title">Skills 榜单</h2><p data-site-copy="body">按 GitHub Stars 排序，支持搜索和分类筛选。Skills 独立展示，不参与插件 Top 100。</p></div>
           <p class="updated" id="updated">更新于：加载中</p>
         </header>
         <div class="category-panel" id="skill-category-filter-panel">
@@ -327,7 +340,7 @@
           <input id="search" type="search" autocomplete="off" maxlength="80" placeholder="搜索 Skill：名称、用途或关键词" aria-label="搜索 Skills" />
 
         </div>
-        <p class="status" id="status" aria-live="polite">正在读取 Skills 目录…</p>
+        <p class="status" id="status" aria-live="polite" data-site-copy="note">正在读取 Skills 目录…</p>
         <div class="skill-list-head" aria-hidden="true"><span>排名</span><span>Skill</span><span>项目简介</span><span class="signal-head">更新与增长</span><span>GitHub Stars</span></div>
         <div class="skill-grid" id="skill-grid"></div>
       </section>
@@ -353,9 +366,9 @@
                 <a class="github-link" href="https://github.com/dsheval/dsh-top100" aria-label="在 GitHub 打开 dsh-top100" title="GitHub" target="_blank" rel="noopener noreferrer">
                   <svg class="github-logo" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .7a11.3 11.3 0 0 0-3.6 22c.6.1.8-.3.8-.6v-2.2c-3.3.7-4-1.4-4-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.9 1.2 1.9 1.2 1.1 1.9 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-6a4.7 4.7 0 0 1 1.2-3.1c-.1-.3-.5-1.6.1-3.1 0 0 1-.3 3.2 1.2a11 11 0 0 1 5.8 0c2.2-1.5 3.2-1.2 3.2-1.2.6 1.5.2 2.8.1 3.1a4.7 4.7 0 0 1 1.2 3.1c0 4.7-2.8 5.7-5.5 6 .4.4.8 1.1.8 2.2v3.2c0 .4.2.7.8.6A11.3 11.3 0 0 0 12 .7Z"></path></svg>
                 </a>
-                <a class="featured-guide" href="./index.html?page=dsh#dsh">安装指南 ↗</a>
+                <a class="featured-guide" href="./index.html?page=dsh#dsh">安装指南 <span aria-hidden="true">→</span></a>
               </div>
-              <div class="skill-details"><p class="description">按需求搜索和推荐 DSH 插件与 Skills，比较用途、安装条件和榜单数据。</p></div>
+              <div class="skill-details"><p class="description" data-site-copy="note">按需求搜索和推荐 DSH 插件与 Skills，比较用途、安装条件和榜单数据。</p></div>
               <span class="rank-exempt" aria-label="不参与评分">—</span>
             </aside>
     </template>
@@ -368,7 +381,7 @@
           <span class="skill-kind">Agent Skill</span>
           <a class="github-link" title="GitHub" target="_blank" rel="noopener noreferrer"><svg class="github-logo" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .7a11.3 11.3 0 0 0-3.6 22c.6.1.8-.3.8-.6v-2.2c-3.3.7-4-1.4-4-1.4-.5-1.4-1.3-1.8-1.3-1.8-1.1-.7.1-.7.1-.7 1.2.1 1.9 1.2 1.9 1.2 1.1 1.9 2.8 1.3 3.5 1 .1-.8.4-1.3.8-1.6-2.7-.3-5.5-1.3-5.5-6a4.7 4.7 0 0 1 1.2-3.1c-.1-.3-.5-1.6.1-3.1 0 0 1-.3 3.2 1.2a11 11 0 0 1 5.8 0c2.2-1.5 3.2-1.2 3.2-1.2.6 1.5.2 2.8.1 3.1a4.7 4.7 0 0 1 1.2 3.1c0 4.7-2.8 5.7-5.5 6 .4.4.8 1.1.8 2.2v3.2c0 .4.2.7.8.6A11.3 11.3 0 0 0 12 .7Z"></path></svg></a>
         </div>
-        <div class="skill-details"><p class="description"></p></div>
+        <div class="skill-details"><p class="description" data-site-copy="note"></p></div>
         <div class="skill-meta" aria-label="项目元数据"><span class="meta-updated"></span><span class="meta-growth"></span></div>
         <span class="stars"></span>
       </article>

--- a/web/public/top300.html
+++ b/web/public/top300.html
@@ -2,12 +2,12 @@
 <html lang="zh-CN">
   <head>
     <meta charset="utf-8" />
-    <meta http-equiv="refresh" content="0; url=/#ranking" />
+    <meta http-equiv="refresh" content="0; url=/top100/#ranking" />
     <meta name="robots" content="noindex" />
     <title>正在前往 dsh-top100</title>
-    <link rel="canonical" href="/" />
+    <link rel="canonical" href="https://dsheval.ai/top100/" />
   </head>
   <body>
-    <p>榜单地址已迁移，正在跳转。<a href="/#ranking">立即打开</a></p>
+    <p>榜单地址已迁移，正在跳转。<a href="/top100/#ranking">立即打开</a></p>
   </body>
 </html>

--- a/web/test/category-tooltip.test.js
+++ b/web/test/category-tooltip.test.js
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+
+// Exercise the real count-update functions after a user has opened a tooltip
+// while the asynchronous catalog is still loading.
+for (const [file, update] of [['index.html', 'updateCategoryCounts'], ['skills.html', 'updateCategoryControls']]) {
+  test(`${file} refreshes an open category tooltip when catalog counts arrive`, () => {
+    const html = readFileSync(new URL(`../public/${file}`, import.meta.url), 'utf8');
+    const source = html.slice(html.indexOf(`function ${update}()`), html.indexOf('function showCategoryDescription(button)'));
+    const countNode = { textContent: '—' };
+    const button = { dataset: { category: 'security' }, querySelector: () => countNode, setAttribute() {} };
+    const tooltip = { hidden: false, dataset: { category: 'security' }, title: '—' };
+    const context = vm.createContext({
+      categoryButtons: [button], categoryDescription: tooltip,
+      categoryLabels: { security: '安全' }, activeCategory: 'security',
+      entries: [{ categories: ['security'] }, { categories: ['security'] }],
+      categoriesOf: entry => entry.categories,
+      manifest: { categories: [{ id: 'security', count: 2, skillCount: 0 }] },
+      formatNumber: String, formatStars: String,
+      showCategoryDescription: target => { tooltip.title = target.querySelector().textContent; },
+    });
+    vm.runInContext(`${source}\n${update}();`, context);
+    assert.equal(countNode.textContent, '2');
+    assert.equal(tooltip.title, '2');
+    tooltip.hidden = true;
+    tooltip.title = 'closed';
+    vm.runInContext(`${update}();`, context);
+    assert.equal(tooltip.title, 'closed', 'data refresh must not open a dismissed tooltip');
+  });
+}

--- a/web/test/description-presentation.test.js
+++ b/web/test/description-presentation.test.js
@@ -6,6 +6,8 @@ test('placeholder Chinese falls back to source without fabricating a summary', (
   assert.equal(descriptionFor({descriptionZh:'demo：现有项目资料不足以生成可靠的功能简介。',description:'Browser automation for agents.'}), 'Browser automation for agents.');
   assert.equal(descriptionFor({descriptionZh:'顺手留颗 Star，作者能高兴一整天',description:''}), '暂无简介');
   assert.equal(descriptionFor({descriptionZh:'为开发者整理研究资料。',description:'Research helper.'}), '为开发者整理研究资料。');
+  assert.equal(descriptionFor({descriptionZh:'版本更新提示：本次版本变化较大，老用户请更新至最新版本。',description:'Generate images from prompts.'}), 'Generate images from prompts.');
+  assert.equal(descriptionFor({descriptionZh:'',description:'--- 🚨 【国内用户核心前置：必须开启系统代理 / TUN 模式！'}), '暂无简介');
 });
 test('reviewed summaries are source-bound and safe to display', () => {
   const reviews=JSON.parse(readFileSync(new URL('../public/reviewed-descriptions.json',import.meta.url),'utf8'));

--- a/web/test/homepage-contract.test.js
+++ b/web/test/homepage-contract.test.js
@@ -116,7 +116,6 @@ test("uses the approved neutral sage palette", () => {
 test("uses the shared footer and keeps Skills outside plugin totals", () => {
   assert.match(html, /<footer class="dsh-site-footer">/);
   assert.match(html, /公开评测，发现值得关注的项目。/);
-  assert.match(html, /class="ranking-source-note"/);
   assert.match(html, /href="\.\/skills\.html#ranking">Skills 榜单/);
   assert.match(html, /manifest\.datasets\.skills\?\.count/);
   assert.doesNotMatch(html, /隐藏 Skill 仓库|hideSkills|manifestSkillCount/);
@@ -141,7 +140,7 @@ test("shares one category interaction system across Plugin and Skills directorie
   assert.match(categoryStyles, /@media \(min-width: 641px\) and \(max-width: 1100px\)[\s\S]*?\.category-count \{ display: none; \}/);
   assert.doesNotMatch(skills, /<select[^>]+id="category"/);
   assert.match(skills, /aria-label="Skill 分类"/);
-  assert.match(html, /当前快照：.*个已验证插件.*已排除.*个 Skills/);
+  assert.match(html, /当前快照：.*个插件.*已排除.*个 Skills/);
 });
 
 test("aligns installation controls and badges while keeping utility text readable", () => {
@@ -242,13 +241,13 @@ test("serves local assets with same-origin production ranking data", () => {
 });
 
 test("keeps the install guide focused and uses the canonical brand name", () => {
-  assert.match(html, /<title>dsh-top100 ·/);
+  assert.match(html, /<title>插件榜单 · Top100 · DSH-Eval<\/title>/);
   assert.match(html, /class="top100-section-title" href="\.\/">[\s\S]*?<span>dsh-top100<\/span>[\s\S]*?<\/a>/);
   for (const page of [html, dsh, skills]) assert.doesNotMatch(page, /dsh-Top100|DSH-Top100/);
   assert.match(html, /body:has\(#dsh-view:not\(\[hidden\]\)\) \.hero \{\s*display: none/);
   assert.match(html, /body:has\(#dsh-view:not\(\[hidden\]\)\) \.ranking \{[^}]*scroll-margin-top: var\(--site-header-height\)/);
   assert.match(html, /#dsh-view \{\s*max-width: 800px/);
-  assert.match(html, /<h1 class="inline-docs-title" id="inline-dsh-title">安装 dsh-top100<\/h1>/);
+  assert.match(html, /<h1 class="inline-docs-title" id="inline-dsh-title">安装指南<\/h1>/);
   assert.match(html, /class="dsh-brand-link" href="\/" aria-label="DSH-Eval 首页"/);
   assert.doesNotMatch(dsh, /dsh-brief-grid|section-kicker|dsh-data-note|3 步完成安装/);
   assert.match(dsh, /网站与插件使用同一份榜单数据/);

--- a/web/test/homepage-contract.test.js
+++ b/web/test/homepage-contract.test.js
@@ -46,13 +46,13 @@ test("places editorial 000 inside the table using shared row styles, without a s
 });
 
 test("boots from lightweight hot data and never falls back to the full catalog", () => {
-  assert.match(html, /const MANIFEST_URL = "\.\/data\/manifest\.json"/);
-  assert.match(html, /hot: "\.\/data\/rankings-hot\.json"/);
-  assert.match(html, /total: "\.\/data\/rankings-total\.json"/);
+  assert.match(html, /const MANIFEST_URL = "\/data\/manifest\.json"/);
+  assert.match(html, /hot: "\/data\/rankings-hot\.json"/);
+  assert.match(html, /total: "\/data\/rankings-total\.json"/);
   assert.match(html, /await fetchJson\(MANIFEST_URL, \{ manifestRequest: true \}\)/);
   assert.match(html, /await fetchJson\(manifest\.datasets\.hot\.url\)/);
   assert.match(html, /falling back to the lightweight legacy hot list/);
-  assert.doesNotMatch(html, /["']\.\/data\/rankings\.json["']/);
+  assert.doesNotMatch(html, /["']\/data\/rankings\.json["']/);
 });
 
 test("loads deferred datasets through their manifest URLs", () => {
@@ -89,7 +89,7 @@ test("contains the homepage conversion, privacy and SEO contracts", () => {
   assert.match(html, /closest\("a\.github-link"\)/);
   assert.doesNotMatch(html, /closest\("\.github-link"\)/);
   assert.doesNotMatch(html, /track\([^\n]+state\.query/);
-  assert.match(html, /rel="canonical" href="https:\/\/www\.dsheval\.ai\/"/);
+  assert.match(html, /rel="canonical" href="https:\/\/dsheval\.ai\/top100\/"/);
   assert.match(html, /type="application\/ld\+json"/);
   assert.doesNotMatch(html, /github\.githubassets\.com\/favicons/);
 });
@@ -113,16 +113,16 @@ test("uses the approved neutral sage palette", () => {
   assert.doesNotMatch(html, /#a95a5a|#fbf4f3/i);
 });
 
-test("softens the footer and keeps Skills outside plugin totals", () => {
-  assert.match(html, /\.footer\s*\{[\s\S]*?min-height:\s*96px/);
-  assert.match(html, /\.footer\s*\{[\s\S]*?background:\s*#2b443d/);
-  assert.match(html, /\.footer span:last-child\s*\{[\s\S]*?color:\s*#c9d6d1/);
+test("uses the shared footer and keeps Skills outside plugin totals", () => {
+  assert.match(html, /<footer class="dsh-site-footer">/);
+  assert.match(html, /公开评测，发现值得关注的项目。/);
+  assert.match(html, /class="ranking-source-note"/);
   assert.match(html, /href="\.\/skills\.html#ranking">Skills 榜单/);
   assert.match(html, /manifest\.datasets\.skills\?\.count/);
   assert.doesNotMatch(html, /隐藏 Skill 仓库|hideSkills|manifestSkillCount/);
   assert.match(skills, /manifest\?\.datasets\?\.skills\?\.url/);
   assert.match(html, /plugin\.type\?\.toLowerCase\(\) === "cordis-plugin"/);
-  assert.match(skills, /const LEGACY_FULL_URL = "\.\/data\/rankings\.json"/);
+  assert.match(skills, /const LEGACY_FULL_URL = "\/data\/rankings\.json"/);
   assert.match(skills, /legacy\?\.rankings\?\.total \?\? legacy\?\.rankings \?\? \[\]/);
   assert.match(skills, /entry\?\.type === "skill"/);
   assert.match(skills, /不参与插件 Top 100/);
@@ -243,13 +243,13 @@ test("serves local assets with same-origin production ranking data", () => {
 
 test("keeps the install guide focused and uses the canonical brand name", () => {
   assert.match(html, /<title>dsh-top100 ·/);
-  assert.match(html, /<span>dsh-top100<\/span>/);
+  assert.match(html, /class="top100-section-title" href="\.\/">[\s\S]*?<span>dsh-top100<\/span>[\s\S]*?<\/a>/);
   for (const page of [html, dsh, skills]) assert.doesNotMatch(page, /dsh-Top100|DSH-Top100/);
   assert.match(html, /body:has\(#dsh-view:not\(\[hidden\]\)\) \.hero \{\s*display: none/);
-  assert.match(html, /body:has\(#dsh-view:not\(\[hidden\]\)\) \.ranking \{[^}]*scroll-margin-top: 64px/);
+  assert.match(html, /body:has\(#dsh-view:not\(\[hidden\]\)\) \.ranking \{[^}]*scroll-margin-top: var\(--site-header-height\)/);
   assert.match(html, /#dsh-view \{\s*max-width: 800px/);
   assert.match(html, /<h1 class="inline-docs-title" id="inline-dsh-title">安装 dsh-top100<\/h1>/);
-  assert.match(html, /class="wordmark" href="\.\/#top"/);
+  assert.match(html, /class="dsh-brand-link" href="\/" aria-label="DSH-Eval 首页"/);
   assert.doesNotMatch(dsh, /dsh-brief-grid|section-kicker|dsh-data-note|3 步完成安装/);
   assert.match(dsh, /网站与插件使用同一份榜单数据/);
   assert.match(dsh, /每日更新/);

--- a/web/test/readme-contract.test.js
+++ b/web/test/readme-contract.test.js
@@ -12,7 +12,7 @@ const rawAssets = "https://raw.githubusercontent.com/dsheval/dsh-top100/main/web
 test("both READMEs introduce the same product and link to the installation guide", () => {
   for (const readme of [githubReadme, npmReadme]) {
     assert.match(readme, /<h1 align="center">dsh-top100\b[^<]*<\/h1>/);
-    assert.ok(readme.includes("https://www.dsheval.ai/?page=dsh#dsh"));
+    assert.ok(readme.includes("https://dsheval.ai/top100/?page=dsh#dsh"));
     assert.match(readme, /发现、安装和管理插件/);
     assert.match(readme, /Skills/);
     assert.doesNotMatch(readme, /一键下载|dsh-Top100/);

--- a/web/test/site-migration.test.js
+++ b/web/test/site-migration.test.js
@@ -122,7 +122,7 @@ test("Top100 pages share one header and footer and retain their section navigati
     assert.ok(header(html).indexOf(">首页</a>") < header(html).indexOf(">Top100</a>"));
     assert.ok(header(html).indexOf(">Top100</a>") < header(html).indexOf(">评测结果</a>"));
     assert.ok(!html.includes('class="nav-shell"'));
-    assert.match(html, /href="\.\/site-chrome\.css\?v=20260905-nav2" \/>\s*<\/head>/);
+    assert.match(html, /href="\.\/site-chrome\.css\?v=20260905-type8c" \/>\s*<\/head>/);
   }
   assert.match(pages[0], /class="nav-links">[\s\S]*?data-content-switch="ranking"/);
   const layout = pages[2].slice(pages[2].indexOf('<div class="docs-layout">'), pages[2].indexOf("</main>"));

--- a/web/test/site-migration.test.js
+++ b/web/test/site-migration.test.js
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { once } from "node:events";
+import test from "node:test";
+
+const repo = new URL("../../", import.meta.url);
+
+test("local preview serves the Top100 mount and preserves old page queries", async (t) => {
+  const server = spawn(process.execPath, ["scripts/serve-dev.mjs"], {
+    cwd: repo,
+    env: { ...process.env, WEB_PORT: "0" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  t.after(async () => {
+    if (server.exitCode === null) {
+      const exited = once(server, "exit");
+      server.kill();
+      await exited;
+    }
+  });
+  const origin = await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("preview did not start")), 5000);
+    let output = "";
+    server.stdout.on("data", (chunk) => {
+      output += chunk;
+      const match = output.match(/Local preview: (http:\/\/127\.0\.0\.1:\d+)/);
+      if (match) { clearTimeout(timeout); resolve(match[1]); }
+    });
+    server.once("error", (error) => { clearTimeout(timeout); reject(error); });
+    server.once("exit", (code) => { clearTimeout(timeout); reject(new Error(`preview exited: ${code}`)); });
+  });
+  for (const [source, destination] of [
+    ["/?page=dsh", "/top100/?page=dsh"],
+    ["/top100?page=docs", "/top100/?page=docs"],
+    ["/skills.html?category=coding", "/top100/skills.html?category=coding"],
+  ]) {
+    const response = await fetch(origin + source, { redirect: "manual" });
+    assert.equal(response.status, 308);
+    assert.equal(response.headers.get("location"), destination);
+    await response.text();
+  }
+  for (const page of ["", "skills.html", "docs.html"]) {
+    const response = await fetch(`${origin}/top100/${page}`);
+    assert.equal(response.status, 200);
+    const html = await response.text();
+    assert.ok(html.includes('aria-label="DSH-Eval 主导航"'));
+    for (const path of ["/", "/results", "/methodology", "/faq", "/top100/"]) {
+      assert.ok(html.includes(`href="${path}"`));
+    }
+    for (const [, path] of html.matchAll(/(?:src|href)="(\.\/[^"?#]+\.(?:css|js|svg))"/g)) {
+      const asset = await fetch(new URL(path, `${origin}/top100/${page}`));
+      assert.equal(asset.status, 200, path);
+      assert.doesNotMatch(asset.headers.get("content-type"), /text\/html/, path);
+      await asset.arrayBuffer();
+    }
+    if (page !== "docs.html") {
+      assert.ok(html.includes('const MANIFEST_URL = "/data/manifest.json"'));
+      assert.ok(!html.includes('"./data/'));
+    }
+  }
+  const events = await fetch(`${origin}/api/events`, { method: "POST" });
+  assert.equal(events.status, 204);
+  const missing = await fetch(`${origin}/top100/missing.js`);
+  assert.equal(missing.status, 404);
+});
+
+test("public catalog links migrate while released plugin data stays compatible", async () => {
+  const read = async (path) => readFile(new URL(path, repo), "utf8");
+  const pkg = JSON.parse(await read("plugin/package.json"));
+  assert.equal(pkg.homepage, "https://dsheval.ai/top100/");
+  const host = await read("plugin/src/host/catalog.ts");
+  assert.ok(host.includes('DEFAULT_DATA_URL = "https://www.dsheval.ai/data"'));
+  const recommendations = await read("plugin/src/host/recommendations.ts");
+  assert.ok(recommendations.includes('DSHEVAL_CATALOG_URL = "https://dsheval.ai/top100/#ranking"'));
+  const client = await read("plugin/src/client/RankingsPage.tsx");
+  assert.ok(client.includes('DSHEVAL_SITE = "https://dsheval.ai/top100/"'));
+  for (const file of ["README.md", "plugin/README.md"]) {
+    const readme = await read(file);
+    assert.ok(readme.includes("https://dsheval.ai/top100/?page=dsh#dsh"));
+    assert.ok(readme.includes("不代表项目已通过能力评测"));
+  }
+});
+
+test("sticky content uses the single shared header while section navigation scrolls with the page", async () => {
+  const read = async (path) => readFile(new URL(path, repo), "utf8");
+  const styles = await read("web/public/site-controls.css");
+  const chrome = await read("web/public/site-chrome.css");
+  assert.match(chrome, /--site-header-height:\s*64px/);
+  assert.doesNotMatch(styles, /--site-main-nav-height|--site-section-nav-height/);
+  const sectionRule = styles.match(/\.top100-section-nav \{([^}]+)\}/)?.[1];
+  assert.ok(sectionRule);
+  assert.doesNotMatch(sectionRule, /position:\s*(sticky|fixed)/);
+  for (const page of ["index.html", "skills.html", "docs.html", "ranking-method.css"]) {
+    const content = await read(`web/public/${page}`);
+    assert.doesNotMatch(content, /(?:^|[;\s])top: 62px;/, page);
+    assert.doesNotMatch(content, /scroll-margin-top: \d+px;/, page);
+    assert.ok(content.includes("top: var(--site-header-height)"), page);
+  }
+  const sitemap = await read("web/public/sitemap.xml");
+  assert.ok(!sitemap.includes("?page="), "client-side views share the catalog canonical URL");
+});
+
+
+test("Top100 pages share one header and footer and retain their section navigation", async () => {
+  const pages = await Promise.all(["index.html", "skills.html", "docs.html"].map((file) =>
+    readFile(new URL(`web/public/${file}`, repo), "utf8")));
+  const normalize = (value) => value.replace(/\s+/g, " ").trim();
+  const header = (html) => html.match(/<header class="dsh-site-header">[\s\S]*?<\/header>/)?.[0];
+  const footer = (html) => html.match(/<footer class="dsh-site-footer">[\s\S]*?<\/footer>/)?.[0];
+  for (const html of pages) {
+    assert.ok(header(html));
+    assert.ok(footer(html));
+    assert.equal(normalize(header(html)), normalize(header(pages[0])));
+    assert.equal(normalize(footer(html)), normalize(footer(pages[0])));
+    assert.equal((html.match(/<main\b/g) ?? []).length, 1);
+    assert.match(html, /<main[^>]*>\s*<nav class="top100-section-nav"/);
+    const section = html.match(/<nav class="top100-section-nav"[\s\S]*?<\/nav>/)[0];
+    for (const label of ["插件榜单", "Skills 榜单", "安装指南", "排名方法", "GitHub"]) assert.ok(section.includes(label));
+    assert.match(section, /<img src="\.\/assets\/dsh-top100-mark\.svg" width="28" height="28" alt=""/);
+    assert.ok(section.includes("<span>dsh-top100</span>"));
+    assert.ok(header(html).indexOf(">首页</a>") < header(html).indexOf(">Top100</a>"));
+    assert.ok(header(html).indexOf(">Top100</a>") < header(html).indexOf(">评测结果</a>"));
+    assert.ok(!html.includes('class="nav-shell"'));
+    assert.match(html, /href="\.\/site-chrome\.css\?v=20260905-nav2" \/>\s*<\/head>/);
+  }
+  assert.match(pages[0], /class="nav-links">[\s\S]*?data-content-switch="ranking"/);
+  const layout = pages[2].slice(pages[2].indexOf('<div class="docs-layout">'), pages[2].indexOf("</main>"));
+  assert.ok(!layout.includes("dsh-site-header") && !layout.includes("top100-section-nav"));
+});


### PR DESCRIPTION
Top100 成为 DSH-Eval 的 `/top100/` 子栏目，插件榜单、Skills、安装指南及排名方法使用同一站点导航。官网、README 和 npm 包元数据指向新入口；已发布插件的数据接口保持 `https://www.dsheval.ai/data`。

- 统一页头页脚和导航字体，保留独立栏目导航与原有双笔画标识，修复窄屏布局。
- 明确收录不等于通过能力评测，简化公开帮助说明；过滤仅含版本提示的简介，并修复异步分类计数提示。
- CI 仅在 PR 和 main push 触发，同一 ref 的旧运行自动取消；完整安全审计独立执行，web/scheduler 镜像分别缓存，保留现有检查。

验证：本地 `npm run check` 的类型检查与 393 项测试通过；完整依赖审计零漏洞；web/scheduler 镜像构建和 actionlint 通过。桌面、窄屏及搜索、筛选、安装入口已验收。本 PR 的 GitHub CI 已通过，本次执行 1 分 41 秒（首次填充镜像缓存；单次耗时不代表稳定基准）：https://github.com/dsheval/dsh-top100/actions/runs/33942670991。

发布：需与 [dsh-eval PR #9](https://github.com/dsheval/dsh-eval/pull/9) 配套，协调更新两个网站和统一网关。npm 元数据及内置链接随后续授权的新版本发布，本 PR 未改版本号，也不部署网站或修改远端 About。
