### PR TITLE
统一 Top100 导航交互与栏目字标层级

### DIFF
--- a/web/public/docs.html
+++ b/web/public/docs.html
@@ -604,25 +604,25 @@
         .doc-section { scroll-margin-top: calc(var(--site-header-height) + 92px); }
       }
     </style>
-    <link rel="stylesheet" href="./site-controls.css?v=20260905-nav2" />
+    <link rel="stylesheet" href="./site-controls.css?v=20260908-section-nav2" />
     <link rel="canonical" href="https://www.dsheval.ai/top100/?page=docs" />
-    <link rel="stylesheet" href="./site-chrome.css?v=20260908-wordmark2" />
+    <link rel="stylesheet" href="./site-chrome.css?v=20260908-nav3" />
   </head>
   <body>
-    <header class="dsh-site-header">
+    <header class="dsh-site-header dsh-nav-emphasis">
       <div class="dsh-site-container dsh-header-inner">
         <a class="dsh-brand-link" href="/" aria-label="DSH-Eval 首页"><span class="dsh-brand" translate="no"><strong>DSH</strong><span aria-hidden="true">/</span><b>EVAL</b></span></a>
-        <nav class="dsh-desktop-nav" aria-label="DSH-Eval 主导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/faq">常见问题</a></nav>
+        <nav class="dsh-desktop-nav" aria-label="DSH-Eval 主导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/about">产品介绍</a></nav>
         <details class="dsh-mobile-menu">
           <summary>菜单<span class="dsh-menu-icon" aria-hidden="true"></span></summary>
-          <nav aria-label="DSH-Eval 移动端导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/faq">常见问题</a></nav>
+          <nav aria-label="DSH-Eval 移动端导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/about">产品介绍</a></nav>
         </details>
       </div>
     </header>
 
     <main>
       <nav class="top100-section-nav" aria-label="Top100 栏目导航">
-        <a class="top100-section-title" href="./"><span>dsh-top100</span></a>
+        <a class="top100-section-title" href="./"><span>Top100</span></a>
         <div class="nav-links">
           <a href="./#ranking">插件榜单</a>
           <a href="./skills.html#ranking">Skills 榜单</a>
@@ -817,7 +817,7 @@
         <nav class="dsh-footer-links" aria-label="页脚导航">
           <a href="https://github.com/dsheval/dsh-eval" target="_blank" rel="noopener noreferrer">评测源码 <span aria-hidden="true">↗</span><span class="dsh-visually-hidden">（新窗口打开）</span></a>
           <a href="https://github.com/dsheval/dsh-top100" target="_blank" rel="noopener noreferrer">Top100 源码 <span aria-hidden="true">↗</span><span class="dsh-visually-hidden">（新窗口打开）</span></a>
-          <a href="/faq">常见问题</a>
+          <a href="/about#faq">常见问题</a>
         </nav>
         <span class="dsh-copyright">© 2026 DSH-Eval</span>
       </div>

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -3048,24 +3048,24 @@
     <link rel="stylesheet" href="./category-system.css" />
     <link rel="stylesheet" href="./ranking-method.css" />
     <link rel="stylesheet" href="./ranking-rows.css" />
-    <link rel="stylesheet" href="./site-controls.css?v=20260905-nav2" />
-    <link rel="stylesheet" href="./site-chrome.css?v=20260908-wordmark2" />
+    <link rel="stylesheet" href="./site-controls.css?v=20260908-section-nav2" />
+    <link rel="stylesheet" href="./site-chrome.css?v=20260908-nav3" />
   </head>
   <body>
-    <header class="dsh-site-header">
+    <header class="dsh-site-header dsh-nav-emphasis">
       <div class="dsh-site-container dsh-header-inner">
         <a class="dsh-brand-link" href="/" aria-label="DSH-Eval 首页"><span class="dsh-brand" translate="no"><strong>DSH</strong><span aria-hidden="true">/</span><b>EVAL</b></span></a>
-        <nav class="dsh-desktop-nav" aria-label="DSH-Eval 主导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/faq">常见问题</a></nav>
+        <nav class="dsh-desktop-nav" aria-label="DSH-Eval 主导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/about">产品介绍</a></nav>
         <details class="dsh-mobile-menu">
           <summary>菜单<span class="dsh-menu-icon" aria-hidden="true"></span></summary>
-          <nav aria-label="DSH-Eval 移动端导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/faq">常见问题</a></nav>
+          <nav aria-label="DSH-Eval 移动端导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/about">产品介绍</a></nav>
         </details>
       </div>
     </header>
 
     <main id="top">
       <nav class="top100-section-nav" aria-label="Top100 栏目导航">
-        <a class="top100-section-title" href="./"><span>dsh-top100</span></a>
+        <a class="top100-section-title" href="./"><span>Top100</span></a>
         <div class="nav-links">
           <a href="#ranking" data-content-switch="ranking">插件榜单</a>
           <a href="./skills.html#ranking">Skills 榜单</a>
@@ -3322,7 +3322,7 @@
         <nav class="dsh-footer-links" aria-label="页脚导航">
           <a href="https://github.com/dsheval/dsh-eval" target="_blank" rel="noopener noreferrer">评测源码 <span aria-hidden="true">↗</span><span class="dsh-visually-hidden">（新窗口打开）</span></a>
           <a href="https://github.com/dsheval/dsh-top100" target="_blank" rel="noopener noreferrer">Top100 源码 <span aria-hidden="true">↗</span><span class="dsh-visually-hidden">（新窗口打开）</span></a>
-          <a href="/faq">常见问题</a>
+          <a href="/about#faq">常见问题</a>
         </nav>
         <span class="dsh-copyright">© 2026 DSH-Eval</span>
       </div>

--- a/web/public/site-chrome.css
+++ b/web/public/site-chrome.css
@@ -364,3 +364,21 @@
     --site-group-title-size: 20px;
   }
 }
+
+/* Keep global navigation in sync with the main site. */
+.dsh-nav-emphasis .dsh-desktop-nav { align-items: center; gap: 8px; }
+.dsh-nav-emphasis .dsh-desktop-nav a { position: relative; min-height: 44px; padding: 0 16px; font-size: 15px; }
+.dsh-nav-emphasis .dsh-desktop-nav a:hover { color: #126657; text-decoration: none; }
+.dsh-nav-emphasis .dsh-desktop-nav a[aria-current='page'] {
+  color: #126657; font-weight: 700; box-shadow: none; text-decoration: none;
+}
+.dsh-nav-emphasis .dsh-desktop-nav a::after {
+  content: ''; position: absolute; bottom: 0; left: 50%; width: 24px;
+  height: 2px; background: #126657; transform: translateX(-50%); opacity: 0;
+}
+.dsh-nav-emphasis .dsh-desktop-nav a:hover::after { opacity: .45; }
+.dsh-nav-emphasis .dsh-desktop-nav a:is([aria-current='page'], :focus-visible)::after { opacity: 1; }
+@media (min-width: 761px) and (max-width: 900px) {
+  .dsh-nav-emphasis .dsh-desktop-nav { gap: 2px; }
+  .dsh-nav-emphasis .dsh-desktop-nav a { padding-inline: 10px; font-size: 14px; }
+}

--- a/web/public/site-controls.css
+++ b/web/public/site-controls.css
@@ -154,13 +154,21 @@
   font-family: var(--site-ui-font);
   letter-spacing: normal;
 }
-.top100-section-title { display: inline-flex; align-items: center; gap: 7px; flex: none; min-height: 52px; color: #13201c; font: 650 18px/1.2 var(--site-ui-font); letter-spacing: -.025em; text-decoration: none; }
+.top100-section-title { display: inline-flex; align-items: center; gap: 7px; flex: none; min-height: 52px; color: #174942; font: 700 22px/1.2 var(--site-ui-font); letter-spacing: -.04em; text-decoration: none; }
+.top100-section-title:hover { color: #126657; }
 .top100-section-title img { display: block; flex: none; }
 .top100-section-nav .nav-links { display: flex; min-width: 0; align-items: center; gap: 28px; overflow-x: auto; }
-.top100-section-nav .nav-links a:nth-child(n) { display: inline-flex; align-items: center; gap: 4px; flex: none; position: relative; min-height: 52px; padding: 0; color: #4f5e59; font: 500 13px/20px var(--site-ui-font); text-decoration: none; white-space: nowrap; }
-.top100-section-nav .nav-links a::after { display: none; }
+.top100-section-nav .nav-links a:nth-child(n) { display: inline-flex; align-items: center; gap: 4px; flex: none; position: relative; min-height: 44px; padding: 0; color: #4f5e59; font: 500 13px/20px var(--site-ui-font); text-decoration: none; white-space: nowrap; }
+.top100-section-nav .nav-links a::after {
+  content: ''; display: block; position: absolute; inset: auto auto 0 50%;
+  width: 24px; height: 2px; background: #126657;
+  transform: translateX(-50%); opacity: 0; transition: none;
+}
 .top100-section-nav .nav-links a:hover { color: #126657; }
-.top100-section-nav .nav-links a[aria-current="page"] { color: #126657; font-weight: 600; box-shadow: inset 0 -2px #126657; }
+.top100-section-nav .nav-links a[aria-current="page"] { color: #126657; font-weight: 600; box-shadow: none; }
+.top100-section-nav .nav-links a:hover::after { opacity: .45; }
+.top100-section-nav .nav-links a:is([aria-current="page"], :focus-visible)::after { opacity: 1; }
+.top100-section-nav .nav-links a[target="_blank"]::after { display: none; }
 .top100-section-nav a:focus-visible { outline: 2px solid #126657; outline-offset: -2px; }
 .top100-section-nav + .hero .hero-inner { padding-top: 64px; }
 .ranking-source-note { margin: 12px 0 0; color: var(--muted); font: 400 13px/1.6 var(--sans); }

--- a/web/public/skills.html
+++ b/web/public/skills.html
@@ -265,24 +265,24 @@
     </style>
     <link rel="stylesheet" href="./category-system.css" />
     <link rel="stylesheet" href="./ranking-rows.css" />
-    <link rel="stylesheet" href="./site-controls.css?v=20260905-nav2" />
-    <link rel="stylesheet" href="./site-chrome.css?v=20260908-wordmark2" />
+    <link rel="stylesheet" href="./site-controls.css?v=20260908-section-nav2" />
+    <link rel="stylesheet" href="./site-chrome.css?v=20260908-nav3" />
   </head>
   <body>
-    <header class="dsh-site-header">
+    <header class="dsh-site-header dsh-nav-emphasis">
       <div class="dsh-site-container dsh-header-inner">
         <a class="dsh-brand-link" href="/" aria-label="DSH-Eval 首页"><span class="dsh-brand" translate="no"><strong>DSH</strong><span aria-hidden="true">/</span><b>EVAL</b></span></a>
-        <nav class="dsh-desktop-nav" aria-label="DSH-Eval 主导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/faq">常见问题</a></nav>
+        <nav class="dsh-desktop-nav" aria-label="DSH-Eval 主导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/about">产品介绍</a></nav>
         <details class="dsh-mobile-menu">
           <summary>菜单<span class="dsh-menu-icon" aria-hidden="true"></span></summary>
-          <nav aria-label="DSH-Eval 移动端导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/faq">常见问题</a></nav>
+          <nav aria-label="DSH-Eval 移动端导航"><a href="/">首页</a><a href="/top100/" aria-current="page">Top100</a><a href="/results">评测结果</a><a href="/methodology">评测方法</a><a href="/about">产品介绍</a></nav>
         </details>
       </div>
     </header>
 
     <main>
       <nav class="top100-section-nav" aria-label="Top100 栏目导航">
-        <a class="top100-section-title" href="./"><span>dsh-top100</span></a>
+        <a class="top100-section-title" href="./"><span>Top100</span></a>
         <div class="nav-links">
           <a href="./index.html#ranking">插件榜单</a>
           <a href="./skills.html#ranking" aria-current="page">Skills 榜单</a>
@@ -354,7 +354,7 @@
         <nav class="dsh-footer-links" aria-label="页脚导航">
           <a href="https://github.com/dsheval/dsh-eval" target="_blank" rel="noopener noreferrer">评测源码 <span aria-hidden="true">↗</span><span class="dsh-visually-hidden">（新窗口打开）</span></a>
           <a href="https://github.com/dsheval/dsh-top100" target="_blank" rel="noopener noreferrer">Top100 源码 <span aria-hidden="true">↗</span><span class="dsh-visually-hidden">（新窗口打开）</span></a>
-          <a href="/faq">常见问题</a>
+          <a href="/about#faq">常见问题</a>
         </nav>
         <span class="dsh-copyright">© 2026 DSH-Eval</span>
       </div>

--- a/web/test/homepage-contract.test.js
+++ b/web/test/homepage-contract.test.js
@@ -242,7 +242,7 @@ test("serves local assets with same-origin production ranking data", () => {
 
 test("keeps the install guide focused and uses the canonical brand name", () => {
   assert.match(html, /<title>插件榜单 · Top100 · DSH-Eval<\/title>/);
-  assert.match(html, /class="top100-section-title" href="\.\/">[\s\S]*?<span>dsh-top100<\/span>[\s\S]*?<\/a>/);
+  assert.match(html, /class="top100-section-title" href="\.\/">[\s\S]*?<span>Top100<\/span>[\s\S]*?<\/a>/);
   for (const page of [html, dsh, skills]) assert.doesNotMatch(page, /dsh-Top100|DSH-Top100/);
   assert.match(html, /body:has\(#dsh-view:not\(\[hidden\]\)\) \.hero \{\s*display: none/);
   assert.match(html, /body:has\(#dsh-view:not\(\[hidden\]\)\) \.ranking \{[^}]*scroll-margin-top: var\(--site-header-height\)/);

--- a/web/test/site-migration.test.js
+++ b/web/test/site-migration.test.js
@@ -45,7 +45,7 @@ test("local preview serves the Top100 mount and preserves old page queries", asy
     assert.equal(response.status, 200);
     const html = await response.text();
     assert.ok(html.includes('aria-label="DSH-Eval 主导航"'));
-    for (const path of ["/", "/results", "/methodology", "/faq", "/top100/"]) {
+    for (const path of ["/", "/results", "/methodology", "/about", "/about#faq", "/top100/"]) {
       assert.ok(html.includes(`href="${path}"`));
     }
     for (const [, path] of html.matchAll(/(?:src|href)="(\.\/[^"?#]+\.(?:css|js|svg))"/g)) {
@@ -124,7 +124,7 @@ test("Top100 pages share one header and footer and retain their section navigati
   const pages = await Promise.all(["index.html", "skills.html", "docs.html"].map((file) =>
     readFile(new URL(`web/public/${file}`, repo), "utf8")));
   const normalize = (value) => value.replace(/\s+/g, " ").trim();
-  const header = (html) => html.match(/<header class="dsh-site-header">[\s\S]*?<\/header>/)?.[0];
+  const header = (html) => html.match(/<header class="dsh-site-header dsh-nav-emphasis">[\s\S]*?<\/header>/)?.[0];
   const footer = (html) => html.match(/<footer class="dsh-site-footer">[\s\S]*?<\/footer>/)?.[0];
   for (const html of pages) {
     assert.ok(header(html));
@@ -136,11 +136,11 @@ test("Top100 pages share one header and footer and retain their section navigati
     const section = html.match(/<nav class="top100-section-nav"[\s\S]*?<\/nav>/)[0];
     for (const label of ["插件榜单", "Skills 榜单", "安装指南", "排名方法", "GitHub"]) assert.ok(section.includes(label));
     assert.doesNotMatch(section, /<img/);
-    assert.ok(section.includes("<span>dsh-top100</span>"));
+    assert.ok(section.includes("<span>Top100</span>"));
     assert.ok(header(html).indexOf(">首页</a>") < header(html).indexOf(">Top100</a>"));
     assert.ok(header(html).indexOf(">Top100</a>") < header(html).indexOf(">评测结果</a>"));
     assert.ok(!html.includes('class="nav-shell"'));
-    assert.match(html, /href="\.\/site-chrome\.css\?v=20260908-wordmark2" \/>\s*<\/head>/);
+    assert.match(html, /href="\.\/site-chrome\.css\?v=20260908-nav3" \/>\s*<\/head>/);
   }
   assert.match(pages[0], /class="nav-links">[\s\S]*?data-content-switch="ranking"/);
   const layout = pages[2].slice(pages[2].indexOf('<div class="docs-layout">'), pages[2].indexOf("</main>"));


### PR DESCRIPTION
统一 Top100 与主站的导航交互和产品介绍、FAQ 入口，栏目导航采用相同位置的短下划线。调整 Top100 字标字号、字重与颜色，并刷新共享样式缓存版本。

验证：npm run check 全部 639 项通过，依赖审计 0 漏洞；网页测试 70/70 通过；共享 site-chrome.css 与主站逐字节相同，浏览器桌面及移动导航、榜单切换和跨站跳转已检查。仅更新网页，不发布 npm 或更改采集服务。
