### PR TITLE
修复榜单表头换行与分页重试

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -4494,7 +4494,7 @@
           loadMore.hidden = currentView !== "all" || (searchActive
             ? shown.length >= matched.length
             : manifest
-              ? categoryPageLoaded >= (category?.pageCount ?? 0)
+              ? shown.length >= matched.length && categoryPageLoaded >= (category?.pageCount ?? 0)
               : shown.length >= matched.length);
           if (!loadMore.hidden) {
             const remaining = Math.max(
@@ -4520,7 +4520,7 @@
             searchActive
               ? shown.length >= matched.length
               : manifest
-                ? totalPageLoaded >= manifest.datasets.total.pageCount
+                ? shown.length >= matched.length && totalPageLoaded >= manifest.datasets.total.pageCount
                 : shown.length >= matched.length
           );
           if (!loadMore.hidden) {
@@ -4716,6 +4716,7 @@
           const requestedCategory = activeCategory;
           const requestedSearchGeneration = searchGenerations[requestedRankingView];
           const state = viewState[requestedRankingView];
+          const requestedVisible = state.visible;
           const searchActive = tokenizeSearchQuery(state.query).length > 0;
           const requestedQuery = normalizeSearchText(state.query);
           const isSameSearchState = () =>
@@ -4730,13 +4731,17 @@
           loadMore.textContent = "正在加载…";
           try {
             if (!requiresSearchIndex(requestedRankingView, state.query, installableOnly) && manifest) {
-              if (requestedCategory) await loadNextCategoryPage();
-              else await loadNextTotalPage();
+              const cachedEntryCount = requestedCategory ? categoryEntries.length : rankedEntries.length;
+              if (requestedVisible >= cachedEntryCount) {
+                if (requestedCategory) await loadNextCategoryPage();
+                else await loadNextTotalPage();
+              }
               const categoryStillMatches = activeCategory === requestedCategory;
               if (categoryStillMatches) {
-                state.unfilteredVisible = requestedCategory
-                  ? categoryEntries.length
-                  : rankedEntries.length;
+                state.unfilteredVisible = Math.min(
+                  requestedVisible + PAGE_SIZE,
+                  requestedCategory ? categoryEntries.length : rankedEntries.length
+                );
                 if (isSameSearchState()) state.visible = state.unfilteredVisible;
               }
             } else {
@@ -4746,6 +4751,7 @@
             if (isCurrentLoadMoreRequest()) renderRanking();
           } catch (error) {
             if (isCurrentLoadMoreRequest()) {
+              renderRanking();
               showFeedback("下一页暂时无法加载，请重试。");
             }
             console.error(error);

--- a/web/public/ranking-rows.css
+++ b/web/public/ranking-rows.css
@@ -3,7 +3,7 @@
   display: grid;
   min-height: 44px;
   padding: 0 18px;
-  grid-template-columns: 50px minmax(160px, 0.78fr) minmax(180px, 1.18fr) 320px 100px;
+  grid-template-columns: 64px minmax(160px, 0.78fr) minmax(180px, 1.18fr) 320px 100px;
   align-items: center;
   gap: 16px;
   border: 1px solid var(--line);
@@ -11,6 +11,10 @@
   background: color-mix(in srgb, var(--section-strong) 55%, var(--card));
   font: 700 13px/1.4 var(--sans);
   letter-spacing: normal;
+}
+
+:is(.list-head, .skill-list-head) span:first-child {
+  white-space: nowrap;
 }
 
 :is(.list-head, .skill-list-head) span:last-child {
@@ -29,7 +33,7 @@
 :is(.plugin-list.is-top100-list .plugin, .skill-card) {
   min-height: 104px;
   padding: 13px 18px;
-  grid-template-columns: 50px minmax(160px, 0.78fr) minmax(180px, 1.18fr) 320px 100px;
+  grid-template-columns: 64px minmax(160px, 0.78fr) minmax(180px, 1.18fr) 320px 100px;
   grid-template-rows: auto;
   align-content: center;
   align-items: center;
@@ -108,7 +112,7 @@
 .skill-meta .meta-updated, .skill-meta .growth-period { white-space: nowrap; }
 .skill-meta .meta-growth:not([hidden]) { display: inline-flex; gap: 12px; }
 
-@media (max-width: 960px) {
+@media (max-width: 980px) {
   :is(.list-head, .skill-list-head), :is(.plugin-list.is-top100-list .plugin, .skill-card) { grid-template-columns: 54px minmax(190px, .78fr) minmax(220px, 1fr) 118px; gap: 16px; }
   :is(.list-head, .skill-list-head) .signal-head { display: none; }
   :is(.plugin-list.is-top100-list .plugin-meta, .skill-meta) { grid-column: 2 / -1; grid-row: 2; }
@@ -185,7 +189,7 @@
     align-self: center;
   }
 }
-@media (min-width: 721px) and (max-width: 960px) {
+@media (min-width: 721px) and (max-width: 980px) {
   .plugin-list.is-top100-list .plugin:not(.featured-plugin) .plugin-description,
   .skill-card:not(.featured-skill) .skill-details {
     grid-row: 1 / 3;

--- a/web/test/ranking-pagination.test.js
+++ b/web/test/ranking-pagination.test.js
@@ -1,0 +1,213 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+import { requiresSearchIndex, filterDiscoveryEntries } from "../public/discovery-filter.js";
+import { normalizeSearchText, tokenizeSearchQuery } from "../public/search-engine.js";
+import { catalogPresentation, catalogInstallCapability, installCommand } from "../public/catalog-presentation.js";
+
+const html = readFileSync(new URL("../public/index.html", import.meta.url), "utf8");
+function sourceBetween(start, end, after = 0) {
+  const first = html.indexOf(start, after);
+  const last = html.indexOf(end, first);
+  assert.ok(first >= 0 && last > first, `missing source section: ${start}`);
+  return html.slice(first, last);
+}
+
+// Run the page's actual rendering, pagination and filter handlers. The DOM stub
+// only records rendered rows and button state; the catalog has three small pages.
+class Element {
+  constructor() {
+    this.dataset = {};
+    this.hidden = false;
+    this.value = "";
+    this.textContent = "";
+    this.children = [];
+    this.nodes = new Map();
+    this.handlers = new Map();
+    this.classList = { add() {}, toggle() {} };
+  }
+  querySelector(selector) {
+    if (!this.nodes.has(selector)) this.nodes.set(selector, new Element());
+    return this.nodes.get(selector);
+  }
+  querySelectorAll() { return []; }
+  setAttribute() {}
+  closest() { return this; }
+  appendChild(node) { this.children.push(node); }
+  prepend(node) { this.children.unshift(node); }
+  replaceChildren(...nodes) {
+    this.children = nodes.flatMap((node) => node.fragment ? node.children : [node]);
+  }
+  addEventListener(type, handler) { this.handlers.set(type, handler); }
+  cloneNode() { return new Element(); }
+  click() { return this.handlers.get("click")(); }
+}
+
+function createPage(category = null) {
+  const entries = Array.from({ length: 250 }, (_, index) => ({
+    rank: index + 1,
+    name: `plugin-${index + 1}`,
+    descriptionZh: "示例插件",
+    plugin: {
+      rank: index + 1, totalRank: index + 1, name: `plugin-${index + 1}`,
+      fullName: `example/plugin-${index + 1}`, type: "cordis-plugin",
+      categories: ["tools"], stars: 1000 - index,
+      installTarget: `github:example/plugin-${index + 1}`,
+    },
+  }));
+  const pages = [0, 1, 2].map((index) => ({ url: `/page-${index}` }));
+  const requests = [];
+  const page = {
+    PAGE_SIZE: 100, currentView: "all", activeCategory: category,
+    activeSearchSort: "relevance", installableOnly: false,
+    viewState: Object.fromEntries(["top100", "rising", "all"].map((view) => [view, {
+      query: "", visible: 100, unfilteredVisible: 100,
+    }])),
+    searchGenerations: { top100: 0, rising: 0, all: 0 },
+    rankedEntries: entries.slice(0, 100), categoryEntries: category ? entries.slice(0, 100) : [],
+    hotEntries: [], risingEntries: [], searchEntries: entries,
+    totalPageLoaded: 1, categoryPageLoaded: category ? 1 : 0,
+    manifest: {
+      datasets: { total: { count: 250, pageCount: pages.length, pages } },
+      categories: [{ id: "tools", count: 250, pageCount: pages.length, pages }],
+    },
+    categoryLabels: { tools: "工具" }, categoryPageLoadPromises: new Map(),
+    totalPageLoadPromise: null, excludedHotSkillCount: 0, revealObserver: null,
+    searchSortButtons: [],
+    requiresSearchIndex, filterDiscoveryEntries, normalizeSearchText, tokenizeSearchQuery,
+    catalogPresentation, catalogInstallCapability, installCommand,
+    makeEntries: (rows) => rows,
+    fetchJson: async (url) => {
+      requests.push(url);
+      const index = pages.findIndex((page) => page.url === url);
+      return { rankings: entries.slice(index * 100, (index + 1) * 100) };
+    },
+    formatStars: (value) => String(Number(value) || 0),
+    entryMatchesCategory: (entry, id) => entry.plugin.categories.includes(id),
+    showFeaturedPlugin: () => false,
+    enhanceDescriptions() {}, observeReveal() {}, track() {}, showFeedback() {},
+    showCategoryDescription() {}, hideCategoryDescription() {},
+    document: {
+      createDocumentFragment: () => Object.assign(new Element(), { fragment: true }),
+      createElement: () => new Element(),
+    },
+  };
+  for (const key of ["featuredPlugin", "searchInput", "list", "listHead", "loadMore",
+    "rankingMetaTitle", "rankHead", "searchClear", "searchSort", "searchResult",
+    "rankingStatus", "installableToggle"]) page[key] = new Element();
+  page.template = { content: new Element() };
+  const allCategoryButton = new Element();
+  allCategoryButton.dataset.category = "";
+  page.categoryButtons = [allCategoryButton];
+  const context = vm.createContext(page);
+  vm.runInContext([
+    sourceBetween("      async function loadNextTotalPage()", "      async function loadSearchEntries()"),
+    sourceBetween("      function renderRanking()", "      function showFeedback(message)"),
+    sourceBetween('      installableToggle.addEventListener("click",', '\n      try {\n        initialDataPromise'),
+    sourceBetween("        for (const button of categoryButtons) {", '\n        loadMore.addEventListener', html.indexOf("        initialDataPromise = loadManifestAndHot()")),
+    sourceBetween('        loadMore.addEventListener("click",', '\n        await setView(currentView'),
+    "function setView() { renderRanking(); }\nrenderRanking();",
+  ].join("\n"), context);
+  return { page, requests, allCategoryButton };
+}
+
+function renderedRanks(page) {
+  return page.list.children.slice(1).map((row) => row.querySelector(".rank").textContent);
+}
+
+for (const category of [null, "tools"]) {
+  test(`${category ?? "total"} pagination remains reachable after installation filtering resets a fully loaded list`, async () => {
+    const { page, requests } = createPage(category);
+    await page.loadMore.click();
+    await page.loadMore.click();
+    assert.equal(renderedRanks(page).length, 250);
+    assert.equal(page.loadMore.hidden, true);
+    assert.equal(requests.length, 2);
+
+    page.installableToggle.click();
+    page.installableToggle.click();
+    assert.equal(renderedRanks(page).length, 100);
+    assert.equal(page.loadMore.hidden, false, "cached results must remain reachable");
+    await page.loadMore.click();
+    assert.equal(renderedRanks(page).length, 200);
+    assert.equal(page.loadMore.hidden, false);
+    await page.loadMore.click();
+    assert.equal(renderedRanks(page).length, 250);
+    assert.equal(page.loadMore.hidden, true);
+    assert.equal(requests.length, 2, "expanding cached rows must not refetch pages");
+    assert.equal(new Set(renderedRanks(page)).size, 250);
+  });
+}
+
+test("reselecting all categories keeps cached total-ranking pages accessible", async () => {
+  const { page, requests, allCategoryButton } = createPage();
+  await page.loadMore.click();
+  await page.loadMore.click();
+  allCategoryButton.click();
+  assert.equal(renderedRanks(page).length, 100);
+  assert.equal(page.loadMore.hidden, false);
+  await page.loadMore.click();
+  await page.loadMore.click();
+  assert.equal(renderedRanks(page).length, 250);
+  assert.equal(requests.length, 2);
+});
+
+test("pagination expands cached rows before requesting the next unloaded page", async () => {
+  const { page, requests } = createPage();
+  await page.loadMore.click();
+  page.installableToggle.click();
+  page.installableToggle.click();
+  await page.loadMore.click();
+  assert.equal(renderedRanks(page).length, 200);
+  assert.equal(requests.length, 1);
+  await page.loadMore.click();
+  assert.equal(renderedRanks(page).length, 250);
+  assert.equal(requests.length, 2);
+  assert.equal(page.loadMore.hidden, true);
+});
+
+for (const category of [null, "tools"]) {
+  test(`${category ?? "total"} pagination restores a retryable button after a page request fails`, async () => {
+    const { page } = createPage(category);
+    const originalFetch = page.fetchJson;
+    let attempts = 0;
+    page.fetchJson = async (url) => {
+      if (++attempts === 1) throw new Error("temporary page failure");
+      return originalFetch(url);
+    };
+    const pending = page.loadMore.click();
+    assert.equal(page.loadMore.textContent, "正在加载…");
+    assert.equal(page.loadMore.disabled, true);
+    await pending;
+    assert.equal(renderedRanks(page).length, 100);
+    assert.equal(page.loadMore.disabled, false);
+    assert.equal(page.loadMore.hidden, false);
+    assert.equal(page.loadMore.textContent, "继续加载（剩余 150）");
+    await page.loadMore.click();
+    assert.equal(attempts, 2);
+    assert.equal(renderedRanks(page).length, 200);
+    assert.equal(page.loadMore.textContent, "继续加载（剩余 50）");
+    assert.equal(page.loadMore.disabled, false);
+  });
+}
+
+test("a pending page does not overwrite a newer search result", async () => {
+  const { page } = createPage();
+  const originalFetch = page.fetchJson;
+  let release;
+  page.fetchJson = async (url) => {
+    await new Promise((resolve) => { release = resolve; });
+    return originalFetch(url);
+  };
+  const pending = page.loadMore.click();
+  page.viewState.all.query = "plugin-250";
+  page.searchGenerations.all += 1;
+  page.setView();
+  const searchRanks = renderedRanks(page);
+  release();
+  await pending;
+  assert.deepEqual(renderedRanks(page), searchRanks);
+  assert.equal(page.viewState.all.visible, 100);
+  assert.equal(page.loadMore.disabled, false);
+});


### PR DESCRIPTION
宽屏总榜排名表头会换行，切换筛选后已缓存的后续条目可能无法继续展开，分页请求失败时按钮也可能停留在加载状态。

增加排名列宽并禁止表头换行，调整平板断点；分页优先展开缓存，失败后恢复重试。新增 7 个真实页面处理器回归用例。

验证：npm run check 共 646 项测试及类型检查通过；独立分页复核 7/7 通过；安全审计无高危或严重问题（2 项中危）；桌面、平板、手机排版已验证。本次仅部署 Web，不发布插件包或更新采集器。
